### PR TITLE
ensure meso-js and post-message-bus are published as public packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,11 +6,10 @@
   ],
 
   "commit": false,
-  "fixed": [
-    ["@meso-network/meso-js", "@meso-network/post-message-bus"]
+  "linked": [
+    ["@meso-network/meso-js", "@meso-network/post-message-bus", "@meso-network/types"]
   ],
-  "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/tame-carpets-explain.md
+++ b/.changeset/tame-carpets-explain.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/post-message-bus": patch
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+---
+
+Ensure `meso-js` and `post-message-bus` are public packages.

--- a/packages/meso-js/package.json
+++ b/packages/meso-js/package.json
@@ -11,9 +11,6 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "publishConfig": {
-    "access": "restricted"
-  },
   "scripts": {
     "typecheck": "tsc -b",
     "build": "vite build",

--- a/packages/post-message-bus/package.json
+++ b/packages/post-message-bus/package.json
@@ -11,9 +11,6 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "publishConfig": {
-    "access": "restricted"
-  },
   "scripts": {
     "typecheck": "tsc -b",
     "build": "vite build",

--- a/packages/post-message-bus/package.json
+++ b/packages/post-message-bus/package.json
@@ -24,6 +24,9 @@
     "url": "git+https://github.com/meso-network/meso-js.git",
     "directory": "packages/meso-js"
   },
+  "dependencies": {
+    "@meso-network/types": "workspace:*"
+  },
   "devDependencies": {
     "jsdom": "^22.1.0"
   }

--- a/packages/post-message-bus/package.json
+++ b/packages/post-message-bus/package.json
@@ -24,9 +24,6 @@
     "url": "git+https://github.com/meso-network/meso-js.git",
     "directory": "packages/meso-js"
   },
-  "dependencies": {
-    "@meso-network/types": "workspace:*"
-  },
   "devDependencies": {
     "jsdom": "^22.1.0"
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meso-network/types",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "Common TypeScript definitions for @meso-network packages.",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,10 +77,6 @@ importers:
         version: 22.1.0
 
   packages/post-message-bus:
-    dependencies:
-      '@meso-network/types':
-        specifier: workspace:*
-        version: link:../types
     devDependencies:
       jsdom:
         specifier: ^22.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,10 @@ importers:
         version: 22.1.0
 
   packages/post-message-bus:
+    dependencies:
+      '@meso-network/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       jsdom:
         specifier: ^22.1.0


### PR DESCRIPTION
With the `0.0.61` release, a bug was introduced that made `@meso-network/types` unavailable when pulling from the registry. This fixes that issue and also ensures packages are made public.