### PR TITLE
fix: remove types dependency from post-message-bus

### DIFF
--- a/.changeset/tricky-eels-notice.md
+++ b/.changeset/tricky-eels-notice.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/post-message-bus": patch
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+---
+
+(Internal code only): Use relative paths to reference types in `post-message-bus`.

--- a/packages/post-message-bus/package.json
+++ b/packages/post-message-bus/package.json
@@ -24,9 +24,6 @@
     "url": "git+https://github.com/meso-network/meso-js.git",
     "directory": "packages/meso-js"
   },
-  "dependencies": {
-    "@meso-network/types": "workspace:*"
-  },
   "devDependencies": {
     "jsdom": "^22.1.0"
   }

--- a/packages/post-message-bus/src/index.ts
+++ b/packages/post-message-bus/src/index.ts
@@ -1,5 +1,5 @@
 import { version } from "../package.json";
 
-export * from "@meso-network/types";
+export * from "../../types";
 export * from "./createPostMessageBus";
 export const MESO_JS_VERSION = version;

--- a/packages/post-message-bus/src/types.ts
+++ b/packages/post-message-bus/src/types.ts
@@ -1,4 +1,4 @@
-import { Transfer, MesoError } from "@meso-network/types";
+import { Transfer, MesoError } from "../../types";
 
 /**
  * Kind of messages sent between the Meso experience and parent window.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,10 +77,6 @@ importers:
         version: 22.1.0
 
   packages/post-message-bus:
-    dependencies:
-      '@meso-network/types':
-        specifier: workspace:*
-        version: link:../types
     devDependencies:
       jsdom:
         specifier: ^22.1.0


### PR DESCRIPTION
This removes the types dependency from post-message-bus.