### PR TITLE
Remove testnets

### DIFF
--- a/.changeset/hip-geckos-compare.md
+++ b/.changeset/hip-geckos-compare.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+"@meso-network/post-message-bus": patch
+---
+
+Remove testnets from `transfer` configuration.

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -154,7 +154,7 @@ buyCrypto.addEventListener("click", () => {
     environment: Environment.SANDBOX, // SANDBOX | PRODUCTION
     sourceAmount: "100", // The amount (in USD) the user will spend
     destinationAsset: Asset.ETH, // The token the user will receive ("ETH" | "SOL" | "USDC")
-    network: Network.ETHEREUM_GOERLI, // The network to use for the transfer
+    network: Network.ETHEREUM_MAINNET, // The network to use for the transfer
     walletAddress: "<WALLET_ADDRESS>", // The user's wallet address obtained at runtime by your application
 
     // A callback to handle events throughout the integration lifecycle
@@ -222,7 +222,7 @@ export const BuyCrypto = () => {
       environment: Environment.SANDBOX, // SANDBOX | PRODUCTION
       sourceAmount: "100", // The amount (in USD) the user will spend
       destinationAsset: Asset.ETH, // The token the user will receive ("ETH" | "SOL" | "USDC")
-      network: Network.ETHEREUM_GOERLI, // The network to use for the transfer
+      network: Network.ETHEREUM_MAINNET, // The network to use for the transfer
       walletAddress: "<WALLET_ADDRESS>", // The user's wallet address obtained at runtime by your application
 
       // A callback to handle events throughout the integration lifecycle
@@ -323,10 +323,7 @@ type TransferConfiguration = {
 
 enum Network {
   ETHEREUM_MAINNET = "eip155:1"
-  ETHEREUM_GOERLI = "eip155:5"
   SOLANA_MAINNET = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-  SOLANA_DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"
-  SOLANA_TESTNET = "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z"
 }
 
 enum DestinationAsset {
@@ -336,9 +333,8 @@ enum DestinationAsset {
 }
 
 enum Environment {
-  // Uses testnets and no fiat currency is moved.
   SANDBOX = "SANDBOX"
-  // Uses mainnet and transfers fiat currency.
+  // Uses mainnet(s) and transfers fiat currency.
   PRODUCTION = "PRODUCTION"
 } as const
 
@@ -660,8 +656,8 @@ This event will fire in the following scenarios:
 
 Meso provides two environments:
 
-- `SANDBOX` – In this environment, testnets will be used to transfer crypto
-  assets. No fiat assets are moved.
+- `SANDBOX` – In this environment, no crypto assets are transferred and no fiat
+  assets are moved.
 - `PRODUCTION` – In this environment, production networks will be used to
   transfer real crypto assets. Fiat assets are moved.
 

--- a/packages/meso-js/test/validateTransferConfiguration.test.ts
+++ b/packages/meso-js/test/validateTransferConfiguration.test.ts
@@ -59,7 +59,7 @@ describe("validateTransferConfiguration", () => {
           "kind": "CONFIGURATION_ERROR",
           "payload": {
             "error": {
-              "message": "\\"network\\" must be a supported network: eip155:1,eip155:5,solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp,solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1,solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z.",
+              "message": "\\"network\\" must be a supported network: eip155:1,solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp.",
             },
           },
         },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -7,7 +7,7 @@ export enum Environment {
   DEV = "DEV",
   /** For office use only. */
   PREVIEW = "PREVIEW",
-  /** In this environment, testnets will be used to transfer crypto assets. No fiat assets are moved. */
+  /** In this environment, no crypto assets are transferred and no fiat assets are moved. */
   SANDBOX = "SANDBOX",
   /** In this environment, production networks will be used to transfer real crypto assets. Fiat assets are moved. */
   PRODUCTION = "PRODUCTION",
@@ -98,10 +98,7 @@ export type SignedMessageResult = Readonly<string> | undefined;
  */
 export enum Network {
   ETHEREUM_MAINNET = "eip155:1",
-  ETHEREUM_GOERLI = "eip155:5",
   SOLANA_MAINNET = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-  SOLANA_DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
-  SOLANA_TESTNET = "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
 }
 
 /**


### PR DESCRIPTION
This removes the testnet options from the `transfer` configuration. Currently, only mainnet configuration is supported and this caused confusion in our sandbox environments.