### PR TITLE
add support for headless message signing

### DIFF
--- a/.changeset/serious-lamps-judge.md
+++ b/.changeset/serious-lamps-judge.md
@@ -1,0 +1,6 @@
+---
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+---
+
+add support for headless message signing

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -318,7 +318,7 @@ type TransferConfiguration = {
   network: Network; // The network to use for the transfer
   walletAddress: string; // The user's wallet address obtained at runtime by your application
   layout?: Layout; // Configuration to customize how the Meso experience is launched and presented
-  headlessSignature?: boolean; // Automatically invoke the `onSignMessageRequest` callback to initiate message signing
+  headlessSignature?: boolean; // Perform message signing in the background without prompting the user. This is useful for embedded wallets
   onSignMessageRequest: (message: string) => Promise<SignedMessageResult>; // A callback that is fired when you need to collect the user's signature via their wallet
   onEvent?: (event: MesoEvent) => void; // An optional handler to notify you when an event or error occurs. This is useful for tracking the state of the user through the experience
 };
@@ -384,17 +384,11 @@ destroy(); // The meso iframe is unmounted. No more events/callbacks will fire.
 
 ### Headless Signature
 
-For partners using embedded wallets, message signing or the existence of a
-wallet itself may be transparent to the end user. In this scenario, it may not
-make sense for the user to be prompted to trigger message signing to either
-verify wallet ownership or approve a transaction.
-
-To support this scenario, you can launch the Meso experience with the
-`headlessSignature` param set to `true`. In doing so, the `onSignMessageRequest`
-callback will be immediately invoked when needed, allowing you to return a
-signed message back to the Meso SDK using the embedded wallet and keeping this
-step completely transparent to the user. Once the signed message is received,
-the rest of the Meso experience proceeds as usual.
+In some cases (such as embedded wallets), message signing may be transparent to
+the end user. You can launch the Meso experience with `headlessSignature: true`
+which will invoke the `onSignMessageRequest` callback immediately allowing you
+to return a signed message back to the Meso SDK using the embedded wallet and
+keeping this step completely transparent to the user.
 
 ### Customizing the layout
 

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -30,6 +30,7 @@ used in a vanilla JavaScript application as well.
   - [Integration lifecycle](#integration-lifecycle)
   - [Reference](#reference)
     - [`transfer`](#transfer)
+    - [Headless Signature](#headless-signature)
     - [Customizing the layout](#customizing-the-layout)
       - [Position](#position)
       - [Offset](#offset)
@@ -317,8 +318,9 @@ type TransferConfiguration = {
   network: Network; // The network to use for the transfer
   walletAddress: string; // The user's wallet address obtained at runtime by your application
   layout?: Layout; // Configuration to customize how the Meso experience is launched and presented
-  onSignMessageRequest: (message: string) => Promise<SignedMessageResult>; // A callback that is fired when you need to collect the user's signature via their wallet.
-  onEvent?: (event: MesoEvent) => void; // An optional handler to notify you when an event or error occurs. This is useful for tracking the state of the user through the experience.
+  headlessSignature?: boolean; // Automatically invoke the `onSignMessageRequest` callback to initiate message signing
+  onSignMessageRequest: (message: string) => Promise<SignedMessageResult>; // A callback that is fired when you need to collect the user's signature via their wallet
+  onEvent?: (event: MesoEvent) => void; // An optional handler to notify you when an event or error occurs. This is useful for tracking the state of the user through the experience
 };
 
 enum Network {
@@ -379,6 +381,20 @@ const { destroy } = transfer({ ... });
 
 destroy(); // The meso iframe is unmounted. No more events/callbacks will fire.
 ```
+
+### Headless Signature
+
+For partners using embedded wallets, message signing or the existence of a
+wallet itself may be transparent to the end user. In this scenario, it may not
+make sense for the user to be prompted to trigger message signing to either
+verify wallet ownership or approve a transaction.
+
+To support this scenario, you can launch the Meso experience with the
+`headlessSignature` param set to `true`. In doing so, the `onSignMessageRequest`
+callback will be immediately invoked when needed, allowing you to return a
+signed message back to the Meso SDK using the embedded wallet and keeping this
+step completely transparent to the user. Once the signed message is received,
+the rest of the Meso experience proceeds as usual.
 
 ### Customizing the layout
 

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -32,6 +32,7 @@ export const transfer = ({
   environment,
   partnerId,
   layout = DEFAULT_LAYOUT,
+  headlessSignature = false,
   onSignMessageRequest,
   onEvent,
 }: TransferConfiguration): TransferInstance => {
@@ -44,6 +45,7 @@ export const transfer = ({
     environment,
     partnerId,
     layout: mergedLayout,
+    headlessSignature,
     onSignMessageRequest,
     onEvent,
   };
@@ -62,6 +64,7 @@ export const transfer = ({
       typeof mergedLayout.offset === "string"
         ? mergedLayout.offset
         : JSON.stringify(mergedLayout.offset),
+    headlessSignature: headlessSignature.toString(),
     version,
   });
   const bus = setupBus(apiHost, frame, onSignMessageRequest, onEvent);

--- a/packages/meso-js/src/validateTransferConfiguration.ts
+++ b/packages/meso-js/src/validateTransferConfiguration.ts
@@ -21,6 +21,7 @@ export const validateTransferConfiguration = ({
   environment,
   partnerId,
   layout,
+  headlessSignature,
   onSignMessageRequest,
   onEvent,
 }: TransferConfiguration): boolean => {
@@ -91,6 +92,14 @@ export const validateTransferConfiguration = ({
     onEvent({
       kind: EventKind.CONFIGURATION_ERROR,
       payload: { error: { message: `"partnerId" must be provided.` } },
+    });
+    return false;
+  } else if (typeof headlessSignature !== "boolean") {
+    onEvent({
+      kind: EventKind.CONFIGURATION_ERROR,
+      payload: {
+        error: { message: '"headlessSignature" must be a boolean.' },
+      },
     });
     return false;
   } else if (typeof onSignMessageRequest !== "function") {

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -15,6 +15,7 @@ describe("setupFrame", () => {
     walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
     sourceAmount: "100",
     destinationAsset: Asset.ETH,
+    headlessSignature: "false",
     layoutPosition: Position.TOP_RIGHT,
     layoutOffset: "0",
     version: "1.0.0",
@@ -30,7 +31,7 @@ describe("setupFrame", () => {
     expect(setupFrameRes.element.attributes).toMatchInlineSnapshot(`
       NamedNodeMap {
         "allowtransparency": "true",
-        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0",
+        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&headlessSignature=false&layoutPosition=top-right&layoutOffset=0&version=1.0.0",
         "style": "position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 9999; box-sizing: border-box; background-color: transparent;",
       }
     `);

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -39,6 +39,7 @@ describe("transfer", () => {
     destinationAsset: Asset.ETH,
     environment: Environment.SANDBOX,
     partnerId: "partnerId",
+    headlessSignature: false,
     layout: DEFAULT_LAYOUT,
     onSignMessageRequest: vi.fn(),
     onEvent: vi.fn(),
@@ -66,6 +67,7 @@ describe("transfer", () => {
         "https://api.sandbox.meso.network",
         {
           "destinationAsset": "ETH",
+          "headlessSignature": "false",
           "layoutOffset": "0",
           "layoutPosition": "top-right",
           "network": "eip155:1",

--- a/packages/meso-js/test/validateTransferConfiguration.test.ts
+++ b/packages/meso-js/test/validateTransferConfiguration.test.ts
@@ -279,6 +279,65 @@ describe("validateTransferConfiguration", () => {
     `);
   });
 
+  test("non-boolean headlessSignature emits", () => {
+    expect(
+      validateTransferConfiguration({
+        onEvent,
+        sourceAmount: "1",
+        network: Network.ETHEREUM_MAINNET,
+        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        destinationAsset: Asset.ETH,
+        environment: Environment.SANDBOX,
+        partnerId: "meso-js-test",
+        // @ts-expect-error: Bypass type system to simulate runtime behavior
+        headlessSignature: "false",
+      }),
+    ).toBe(false);
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "CONFIGURATION_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"headlessSignature\\" must be a boolean.",
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  test("non-function onSignMessageRequest emits", () => {
+    expect(
+      validateTransferConfiguration({
+        onEvent,
+        sourceAmount: "1",
+        network: Network.ETHEREUM_MAINNET,
+        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        destinationAsset: Asset.ETH,
+        environment: Environment.SANDBOX,
+        partnerId: "meso-js-test",
+        headlessSignature: false,
+        // @ts-expect-error: Bypass type system to simulate runtime behavior
+        onSignMessageRequest: "signedMessage",
+      }),
+    ).toBe(false);
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "CONFIGURATION_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"onSignMessageRequest\\" must be a valid function.",
+            },
+          },
+        },
+      ]
+    `);
+  });
+
   describe("layout", () => {
     test("invalid `position` emits an error", () => {
       expect(
@@ -291,6 +350,7 @@ describe("validateTransferConfiguration", () => {
           destinationAsset: Asset.ETH,
           environment: Environment.SANDBOX,
           partnerId: "meso-js-test",
+          headlessSignature: false,
           // @ts-expect-error: Bypass type system to simulate runtime behavior
           layout: { position: "bottom-center" },
         }),
@@ -323,6 +383,7 @@ describe("validateTransferConfiguration", () => {
           destinationAsset: Asset.ETH,
           environment: Environment.SANDBOX,
           partnerId: "meso-js-test",
+          headlessSignature: false,
         };
       });
 
@@ -527,36 +588,6 @@ describe("validateTransferConfiguration", () => {
     });
   });
 
-  test("non-function onSignMessageRequest emits", () => {
-    expect(
-      validateTransferConfiguration({
-        onEvent,
-        sourceAmount: "1",
-        network: Network.ETHEREUM_MAINNET,
-        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        destinationAsset: Asset.ETH,
-        environment: Environment.SANDBOX,
-        partnerId: "meso-js-test",
-        layout: { position: Position.TOP_RIGHT, offset: "0" },
-        // @ts-expect-error: Bypass type system to simulate runtime behavior
-        onSignMessageRequest: "signedMessage",
-      }),
-    ).toBe(false);
-    expect(onEvent).toHaveBeenCalledOnce();
-    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "CONFIGURATION_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"onSignMessageRequest\\" must be a valid function.",
-            },
-          },
-        },
-      ]
-    `);
-  });
-
   describe("valid configuration", () => {
     test("returns true (no layout)", () => {
       const valid = validateTransferConfiguration({
@@ -567,6 +598,7 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
+        headlessSignature: false,
         onSignMessageRequest: vi.fn(),
       });
       expect(onEvent).not.toHaveBeenCalled();
@@ -582,6 +614,7 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
+        headlessSignature: false,
         layout: { offset: "0" },
         onSignMessageRequest: vi.fn(),
       });
@@ -598,6 +631,7 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
+        headlessSignature: false,
         layout: { position: Position.TOP_RIGHT, offset: "0" },
         onSignMessageRequest: vi.fn(),
       });
@@ -614,6 +648,7 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
+        headlessSignature: false,
         layout: { position: Position.TOP_RIGHT, offset: "0" },
         onSignMessageRequest: vi.fn(),
       });
@@ -630,6 +665,7 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
+        headlessSignature: false,
         layout: { position: Position.TOP_RIGHT, offset: { horizontal: "10" } },
         onSignMessageRequest: vi.fn(),
       });
@@ -646,6 +682,7 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
+        headlessSignature: false,
         layout: {
           position: Position.TOP_RIGHT,
           offset: { horizontal: "10", vertical: "22" },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -219,8 +219,8 @@ export type TransferConfiguration = Readonly<{
    */
   layout?: Layout;
   /**
-   * Automatically invoke the `onSignMessageRequest` callback to initiate
-   * message signing.
+   * Perform message signing in the background without prompting the user. This
+   * is useful for embedded wallets.
    */
   headlessSignature?: boolean;
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -219,6 +219,11 @@ export type TransferConfiguration = Readonly<{
    */
   layout?: Layout;
   /**
+   * Automatically invoke the `onSignMessageRequest` callback to initiate
+   * message signing.
+   */
+  headlessSignature?: boolean;
+  /**
    * A handler to notify you when a message needs to be signed.
    */
   onSignMessageRequest: (message: string) => Promise<SignedMessageResult>;
@@ -238,6 +243,7 @@ export type TransferIframeParams = Pick<
   | "walletAddress"
   | "sourceAmount"
   | "destinationAsset"
+  | "headlessSignature"
 > & {
   layoutPosition: NonNullable<Layout["position"]>;
   layoutOffset: NonNullable<Layout["offset"]>;
@@ -256,6 +262,7 @@ export type SerializedTransferIframeParams = Record<
   | "destinationAsset"
   | "layoutPosition"
   | "layoutOffset"
+  | "headlessSignature"
   | "version",
   string
 >;


### PR DESCRIPTION
For partners using embedded wallets, message signing or the existence of a wallet itself may be transparent to the end user. In this scenario, it may not make sense for the user to be prompted to trigger message signing to either verify wallet ownership or approve a transaction.

To support this scenario, you can launch the Meso experience with the `headlessSignature` param set to `true`. In doing so, the `onSignMessageRequest` callback will be immediately invoked when needed, allowing you to return a signed message back to the Meso SDK using the embedded wallet and keeping this step completely transparent to the user. Once the signed message is received, the rest of the Meso experience proceeds as usual.