### PR TITLE
fixed changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
 
   "commit": false,
-  "linked": [
+  "fixed": [
     ["@meso-network/meso-js", "@meso-network/post-message-bus", "@meso-network/types"]
   ],
   "access": "public",

--- a/.changeset/red-seas-juggle.md
+++ b/.changeset/red-seas-juggle.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/meso-js": patch
+"@meso-network/post-message-bus": patch
+"@meso-network/types": patch
+---
+
+fix instead of link changesets for all modules


### PR DESCRIPTION
Update changeset config to mark all modules as fixed, not linked. Per [the docs](https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md):

Fixed packages allow you to specify a group or groups of packages that should be versioned and published together. Unlike linked packages, all packages in the group of fixed packages will be version-bumped and published together even when there are no changes done to some of the the member packages.

Linked packages will still only be bumped when there is a changeset for them (this can mean because you explicitly choose to add a changeset for it or because it's a dependent of something being released).