### PR TITLE
add unsupported network/asset error

### DIFF
--- a/.changeset/metal-jars-travel.md
+++ b/.changeset/metal-jars-travel.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/post-message-bus": patch
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+---
+
+add unsupported network/asset errors

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -562,7 +562,7 @@ transfer({
 
 #### Unsupported Asset errors
 
-If the `destinateionAsset` that you provided in the configuration isn't
+If the `destinationAsset` that you provided in the configuration isn't
 currently supported, an `UNSUPPORTED_ASSET_ERROR` will be provided to your
 [`onEvent`](#transfer) callback. This error may occur for assets we're in the
 process of adding support for or if a previously supported asset is not

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -36,12 +36,16 @@ used in a vanilla JavaScript application as well.
       - [Offset](#offset)
     - [Handling errors](#handling-errors)
       - [Configuration errors](#configuration-errors)
+      - [Unsupported Network errors](#unsupported-network-errors)
+      - [Unsupported Asset errors](#unsupported-asset-errors)
       - [Other errors](#other-errors)
     - [Events](#events)
       - [`TRANSFER_APPROVED`](#transfer_approved)
       - [`TRANSFER_COMPLETE`](#transfer_complete)
       - [`ERROR`](#error)
       - [`CONFIGURATION_ERROR`](#configuration_error)
+      - [`UNSUPPORTED_NETWORK_ERROR`](#unsupported_network_error)
+      - [`UNSUPPORTED_ASSET_ERROR`](#unsupported_asset_error)
       - [`CLOSE`](#close)
   - [Environments](#environments)
   - [Testing](#testing)
@@ -174,6 +178,16 @@ buyCrypto.addEventListener("click", () => {
           console.error(payload.error.message);
           break;
 
+        // The `network` provided in the configuration is not supported
+        case EventKind.UNSUPPORTED_NETWORK_ERROR:
+          console.error(payload.error.message);
+          break;
+
+        // The `destinationAsset` provided in the configuration is not supported
+        case EventKind.UNSUPPORTED_ASSET_ERROR:
+          console.error(payload.error.message);
+          break;
+
         // A general error has occurred
         case EventKind.ERROR:
           console.error(payload.error.message);
@@ -239,6 +253,16 @@ export const BuyCrypto = () => {
 
           // There was an issue with the provided configuration
           case EventKind.CONFIGURATION_ERROR:
+            console.error(payload.error.message);
+            break;
+
+          // The `network` provided in the configuration is not supported
+          case EventKind.UNSUPPORTED_NETWORK_ERROR:
+            console.error(payload.error.message);
+            break;
+
+          // The `destinationAsset` provided in the configuration is not supported
+          case EventKind.UNSUPPORTED_ASSET_ERROR:
             console.error(payload.error.message);
             break;
 
@@ -502,6 +526,74 @@ transfer({
 
 If you do not provide the `onEvent` callback, `meso-js` will `throw` an exception.
 
+#### Unsupported Network errors
+
+If the `network` that you provided in the configuration isn't currently
+supported, an `UNSUPPORTED_NETWORK_ERROR` will be provided to your
+[`onEvent`](#transfer) callback. This error may occur for networks we're in the
+process of adding support for or if a previously supported network is not
+currently supported.
+
+**Type:**
+
+```ts
+// An error surfaced from the `meso-js` integration.
+type MesoError = {
+  // A client-friendly error message.
+  message: string;
+};
+
+type UnsupportedNetworkErrorPayload = { error: MesoError };
+```
+
+**Example:**
+
+```ts
+transfer({
+  // ...
+  onEvent: (event: MesoEvent) => {
+    if (event.kind === EventKind.UNSUPPORTED_NETWORK_ERROR) {
+      // handle unsupported network error
+      console.log(event.payload.error.message); // "some error message"
+    }
+  },
+});
+```
+
+#### Unsupported Asset errors
+
+If the `destinateionAsset` that you provided in the configuration isn't
+currently supported, an `UNSUPPORTED_ASSET_ERROR` will be provided to your
+[`onEvent`](#transfer) callback. This error may occur for assets we're in the
+process of adding support for or if a previously supported asset is not
+currently supported.
+
+**Type:**
+
+```ts
+// An error surfaced from the `meso-js` integration.
+type MesoError = {
+  // A client-friendly error message.
+  message: string;
+};
+
+type UnsupportedAssetErrorPayload = { error: MesoError };
+```
+
+**Example:**
+
+```ts
+transfer({
+  // ...
+  onEvent: (event: MesoEvent) => {
+    if (event.kind === EventKind.UNSUPPORTED_ASSET_ERROR) {
+      // handle unsupported asset error
+      console.log(event.payload.error.message); // "some error message"
+    }
+  },
+});
+```
+
 #### Other errors
 
 Other errors dispatched during the integration will also be surfaced via the
@@ -553,6 +645,12 @@ onEvent({kind, payload}: MesoEvent) {
     console.log(payload); // { transfer: { ... }}
     break;
   case EventKind.CONFIGURATION_ERROR:
+    console.log(payload); // { message: "an error message" }
+    break;
+  case EventKind.UNSUPPORTED_NETWORK_ERROR:
+    console.log(payload); // { message: "an error message" }
+    break;
+  case EventKind.UNSUPPORTED_ASSET_ERROR:
     console.log(payload); // { message: "an error message" }
     break;
   case EventKind.ERROR:
@@ -639,6 +737,42 @@ See [configuration errors](#configuration-errors) for more.
   kind: "CONFIGURATION_ERROR",
   payload: {
     message: "Invalid ETH wallet address."
+  }
+}
+```
+
+#### `UNSUPPORTED_NETWORK_ERROR`
+
+This event is fired when the `network` provided in the `transfer` configuration
+is not supported.
+
+See [unsupported network errors](#unsupported-network-errors) for more.
+
+**Example payload:**
+
+```ts
+{
+  kind: "UNSUPPORTED_NETWORK_ERROR",
+  payload: {
+    message: "\"network\" must be a supported network: eip155:1,solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp,eip155:137."
+  }
+}
+```
+
+#### `UNSUPPORTED_ASSET_ERROR`
+
+This event is fired when the `destinationAsset` provided in the `transfer`
+configuration is not supported.
+
+See [unsupported asset errors](#unsupported-asset-errors) for more.
+
+**Example payload:**
+
+```ts
+{
+  kind: "UNSUPPORTED_ASSET_ERROR",
+  payload: {
+    message: "\"destinationAsset\" must be a supported asset: ETH,SOL,USDC,MATIC.",
   }
 }
 ```

--- a/packages/meso-js/src/bus.ts
+++ b/packages/meso-js/src/bus.ts
@@ -77,5 +77,21 @@ export const setupBus = (
     });
   });
 
+  bus.on(MessageKind.UNSUPPORTED_NETWORK_ERROR, (message) => {
+    if (message.kind !== MessageKind.UNSUPPORTED_NETWORK_ERROR) return;
+    onEvent({
+      kind: EventKind.UNSUPPORTED_NETWORK_ERROR,
+      payload: { error: message.payload },
+    });
+  });
+
+  bus.on(MessageKind.UNSUPPORTED_ASSET_ERROR, (message) => {
+    if (message.kind !== MessageKind.UNSUPPORTED_ASSET_ERROR) return;
+    onEvent({
+      kind: EventKind.UNSUPPORTED_ASSET_ERROR,
+      payload: { error: message.payload },
+    });
+  });
+
   return bus;
 };

--- a/packages/meso-js/src/validateTransferConfiguration.ts
+++ b/packages/meso-js/src/validateTransferConfiguration.ts
@@ -40,7 +40,7 @@ export const validateTransferConfiguration = ({
     return false;
   } else if (!isValidNetwork(network)) {
     onEvent({
-      kind: EventKind.CONFIGURATION_ERROR,
+      kind: EventKind.UNSUPPORTED_NETWORK_ERROR,
       payload: {
         error: {
           message: `"network" must be a supported network: ${Object.values(
@@ -62,7 +62,7 @@ export const validateTransferConfiguration = ({
     return false;
   } else if (!(destinationAsset in Asset)) {
     onEvent({
-      kind: EventKind.CONFIGURATION_ERROR,
+      kind: EventKind.UNSUPPORTED_ASSET_ERROR,
       payload: {
         error: {
           message: `"destinationAsset" must be a supported asset: ${Object.values(

--- a/packages/meso-js/test/bus.test.ts
+++ b/packages/meso-js/test/bus.test.ts
@@ -250,4 +250,66 @@ describe("setupBus", () => {
       ]
     `);
   });
+
+  test("returns bus which handles UNSUPPORTED_NETWORK_ERROR message", () => {
+    const onMock = vi.fn();
+    createPostMessageBusMock.mockImplementationOnce(() => ({ on: onMock }));
+
+    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    expect(onMock).toBeCalledWith(
+      MessageKind.UNSUPPORTED_NETWORK_ERROR,
+      expect.any(Function),
+    );
+    const onErrorCallback = onMock.mock.calls.find(
+      (invocationArgs) =>
+        invocationArgs[0] === MessageKind.UNSUPPORTED_NETWORK_ERROR,
+    )[1];
+    onErrorCallback({
+      kind: MessageKind.UNSUPPORTED_NETWORK_ERROR,
+      payload: "unsupportedNetworkErrorPayload",
+    });
+
+    expect(onEventMock).toHaveBeenCalledOnce();
+    expect(onEventMock.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "UNSUPPORTED_NETWORK_ERROR",
+          "payload": {
+            "error": "unsupportedNetworkErrorPayload",
+          },
+        },
+      ]
+    `);
+  });
+
+  test("returns bus which handles UNSUPPORTED_ASSET_ERROR message", () => {
+    const onMock = vi.fn();
+    createPostMessageBusMock.mockImplementationOnce(() => ({ on: onMock }));
+
+    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    expect(onMock).toBeCalledWith(
+      MessageKind.UNSUPPORTED_ASSET_ERROR,
+      expect.any(Function),
+    );
+    const onErrorCallback = onMock.mock.calls.find(
+      (invocationArgs) =>
+        invocationArgs[0] === MessageKind.UNSUPPORTED_ASSET_ERROR,
+    )[1];
+    onErrorCallback({
+      kind: MessageKind.UNSUPPORTED_ASSET_ERROR,
+      payload: "unsupportedAssetErrorPayload",
+    });
+
+    expect(onEventMock).toHaveBeenCalledOnce();
+    expect(onEventMock.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "UNSUPPORTED_ASSET_ERROR",
+          "payload": {
+            "error": "unsupportedAssetErrorPayload",
+          },
+        },
+      ]
+    `);
+  });
 });

--- a/packages/meso-js/test/validateTransferConfiguration.test.ts
+++ b/packages/meso-js/test/validateTransferConfiguration.test.ts
@@ -56,7 +56,7 @@ describe("validateTransferConfiguration", () => {
     expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
       [
         {
-          "kind": "CONFIGURATION_ERROR",
+          "kind": "UNSUPPORTED_NETWORK_ERROR",
           "payload": {
             "error": {
               "message": "\\"network\\" must be a supported network: eip155:1,solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp.",
@@ -157,7 +157,7 @@ describe("validateTransferConfiguration", () => {
     expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
       [
         {
-          "kind": "CONFIGURATION_ERROR",
+          "kind": "UNSUPPORTED_ASSET_ERROR",
           "payload": {
             "error": {
               "message": "\\"destinationAsset\\" must be a supported asset: ETH,SOL,USDC.",

--- a/packages/post-message-bus/src/types.ts
+++ b/packages/post-message-bus/src/types.ts
@@ -31,11 +31,11 @@ export enum MessageKind {
   /**
    * Dispatch an unsupported network error when the `network` passed to initialize the Meso experience is not supported.
    */
-  UNSUPPORTED_NETWORK_ERROR = "UNSUPOPRTED_NETWORK_ERROR",
+  UNSUPPORTED_NETWORK_ERROR = "UNSUPPORTED_NETWORK_ERROR",
   /**
    * Dispatch an unsupported asset error when the `destinationAsset` passed to initialize the Meso experience is not supported.
    */
-  UNSUPPORTED_ASSET_ERROR = "UNSUPOPRTED_ASSET_ERROR",
+  UNSUPPORTED_ASSET_ERROR = "UNSUPPORTED_ASSET_ERROR",
 }
 
 export type RequestSignedMessagePayload = {

--- a/packages/post-message-bus/src/types.ts
+++ b/packages/post-message-bus/src/types.ts
@@ -28,6 +28,14 @@ export enum MessageKind {
    * Dispatch a configuration error when the Meso experience cannot be initialized.
    */
   CONFIGURATION_ERROR = "CONFIGURATION_ERROR",
+  /**
+   * Dispatch an unsupported network error when the `network` passed to initialize the Meso experience is not supported.
+   */
+  UNSUPPORTED_NETWORK_ERROR = "UNSUPOPRTED_NETWORK_ERROR",
+  /**
+   * Dispatch an unsupported asset error when the `destinationAsset` passed to initialize the Meso experience is not supported.
+   */
+  UNSUPPORTED_ASSET_ERROR = "UNSUPOPRTED_ASSET_ERROR",
 }
 
 export type RequestSignedMessagePayload = {
@@ -76,7 +84,9 @@ export type Message =
         Partial<Pick<Transfer, "networkTransactionId">>;
     }
   | { kind: MessageKind.ERROR; payload: MesoError }
-  | { kind: MessageKind.CONFIGURATION_ERROR; payload: MesoError };
+  | { kind: MessageKind.CONFIGURATION_ERROR; payload: MesoError }
+  | { kind: MessageKind.UNSUPPORTED_NETWORK_ERROR; payload: MesoError }
+  | { kind: MessageKind.UNSUPPORTED_ASSET_ERROR; payload: MesoError };
 
 export type PostMessageHandlerFn = (
   message: Message,

--- a/packages/post-message-bus/src/validators.ts
+++ b/packages/post-message-bus/src/validators.ts
@@ -85,6 +85,8 @@ export const validateMessage = (message: Message) => {
       return true;
     case MessageKind.ERROR:
     case MessageKind.CONFIGURATION_ERROR:
+    case MessageKind.UNSUPPORTED_NETWORK_ERROR:
+    case MessageKind.UNSUPPORTED_ASSET_ERROR:
       if (!("payload" in message)) {
         return false;
       }

--- a/packages/post-message-bus/test/validators.test.ts
+++ b/packages/post-message-bus/test/validators.test.ts
@@ -317,6 +317,86 @@ describe("validators", () => {
     });
   });
 
+  describe("UNSUPPORTED_NETWORK_ERROR", () => {
+    describe("success", () => {
+      test("is valid", () => {
+        expect(
+          validateMessage({
+            kind: MessageKind.UNSUPPORTED_NETWORK_ERROR,
+            payload: { message: "an UNSUPPORTED_NETWORK_ERROR" },
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("failure", () => {
+      test.each([
+        [
+          "bad payload (invalid message type)",
+          {
+            kind: MessageKind.UNSUPPORTED_NETWORK_ERROR,
+            payload: { message: false },
+          },
+        ],
+        [
+          "bad payload (empty message)",
+          {
+            kind: MessageKind.UNSUPPORTED_NETWORK_ERROR,
+            payload: { message: "" },
+          },
+        ],
+        [
+          "bad payload (missing message)",
+          { kind: MessageKind.UNSUPPORTED_NETWORK_ERROR, payload: {} },
+        ],
+        ["missing kind", { payload: { message: "an error" } }],
+      ])("%s", (_, message) => {
+        // @ts-expect-error: Bypass type system to simulate runtime behavior
+        expect(validateMessage(message)).toBe(false);
+      });
+    });
+  });
+
+  describe("UNSUPPORTED_ASSET_ERROR", () => {
+    describe("success", () => {
+      test("is valid", () => {
+        expect(
+          validateMessage({
+            kind: MessageKind.UNSUPPORTED_ASSET_ERROR,
+            payload: { message: "an UNSUPPORTED_ASSET_ERROR" },
+          }),
+        ).toBe(true);
+      });
+    });
+
+    describe("failure", () => {
+      test.each([
+        [
+          "bad payload (invalid message type)",
+          {
+            kind: MessageKind.UNSUPPORTED_ASSET_ERROR,
+            payload: { message: false },
+          },
+        ],
+        [
+          "bad payload (empty message)",
+          {
+            kind: MessageKind.UNSUPPORTED_ASSET_ERROR,
+            payload: { message: "" },
+          },
+        ],
+        [
+          "bad payload (missing message)",
+          { kind: MessageKind.UNSUPPORTED_ASSET_ERROR, payload: {} },
+        ],
+        ["missing kind", { payload: { message: "an error" } }],
+      ])("%s", (_, message) => {
+        // @ts-expect-error: Bypass type system to simulate runtime behavior
+        expect(validateMessage(message)).toBe(false);
+      });
+    });
+  });
+
   describe("validateHandlerFunction()", () => {
     describe("success", () => {
       test("for valid handler", () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -62,12 +62,18 @@ export type TransferCompletePayload = {
 };
 export type ErrorPayload = { error: MesoError };
 export type ConfigurationErrorPayload = { error: MesoError };
+export type UnsupportedNetworkErrorPayload = { error: MesoError };
+export type UnsupportedAssetErrorPayload = { error: MesoError };
 
 export enum EventKind {
   /** An error has occurred while the Meso experience was active.  */
   ERROR = "ERROR",
   /** An error has occurred while initializing the Meso experience. */
   CONFIGURATION_ERROR = "CONFIGURATION_ERROR",
+  /** The `network` provided in the configuration is not supported. */
+  UNSUPPORTED_NETWORK_ERROR = "UNSUPPORTED_NETWORK_ERROR",
+  /** The `destinationAsset` provided in the configuration is not supported. */
+  UNSUPPORTED_ASSET_ERROR = "UNSUPPORTED_ASSET_ERROR",
   /** The user manually exited the Meso experience. */
   CLOSE = "CLOSE",
   /** A Meso transfer has been approved */
@@ -84,6 +90,14 @@ export type MesoEvent =
   | { kind: EventKind.TRANSFER_COMPLETE; payload: TransferCompletePayload }
   | { kind: EventKind.ERROR; payload: ErrorPayload }
   | { kind: EventKind.CONFIGURATION_ERROR; payload: ConfigurationErrorPayload }
+  | {
+      kind: EventKind.UNSUPPORTED_NETWORK_ERROR;
+      payload: UnsupportedNetworkErrorPayload;
+    }
+  | {
+      kind: EventKind.UNSUPPORTED_ASSET_ERROR;
+      payload: UnsupportedAssetErrorPayload;
+    }
   | { kind: EventKind.CLOSE; payload: null };
 
 /**


### PR DESCRIPTION
Ahead of launching support for additional networks and assets, we are introducing more precise errors for unsupported networks/assets.