### PR TITLE
fix(@meso-network/post-message-bus): 🐛 safely lookup parent origins across browsers 

### DIFF
--- a/.changeset/lemon-toys-breathe.md
+++ b/.changeset/lemon-toys-breathe.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/post-message-bus": patch
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+---
+
+Safely lookup parent origins across browsers when initializing post message bus.

--- a/packages/post-message-bus/src/createPostMessageBus.ts
+++ b/packages/post-message-bus/src/createPostMessageBus.ts
@@ -21,6 +21,14 @@ const logError = (message: string) => {
   console.error(generateLogMessage(message));
 };
 
+export const getParentWindowOrigin = () => {
+  if ("ancestorOrigins" in location) {
+    return location.ancestorOrigins[0];
+  }
+
+  return new URL(document.referrer).origin;
+};
+
 export const createPostMessageBus = (
   targetOrigin: string,
 ): PostMessageBus | PostMessageBusInitializationError => {
@@ -32,10 +40,7 @@ export const createPostMessageBus = (
   }
 
   let postMessageWindow: Window;
-  if (
-    window.location.ancestorOrigins &&
-    window.location.ancestorOrigins[0] === targetOrigin
-  ) {
+  if (getParentWindowOrigin() === targetOrigin) {
     // target is parent, currently in iframe
     postMessageWindow = window.parent;
   } else {

--- a/packages/post-message-bus/test/setupTests.ts
+++ b/packages/post-message-bus/test/setupTests.ts
@@ -18,4 +18,9 @@ beforeAll(() => {
     },
     writable: true,
   });
+
+  Object.defineProperty(document, "referrer", {
+    value: PARTNER_APP_ORIGIN,
+    configurable: true,
+  });
 });


### PR DESCRIPTION
Previously, we were using only [`ancestorOrigins`](https://developer.mozilla.org/en-US/docs/Web/API/Location/ancestorOrigins) which is unsupported in [Firefox](https://developer.mozilla.org/en-US/docs/Web/API/Location/ancestorOrigins#browser_compatibility).

This PR introduces a fallback lookup mechanism using [`document.referrer`](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer).