### PR TITLE
fix(@meso-network/post-message-bus): introduce guard when looking up document.referrer

### DIFF
--- a/.changeset/serious-points-provide.md
+++ b/.changeset/serious-points-provide.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/post-message-bus": patch
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+---
+
+Gracefully handle missing `document.referrer`

--- a/packages/post-message-bus/src/createPostMessageBus.ts
+++ b/packages/post-message-bus/src/createPostMessageBus.ts
@@ -24,9 +24,9 @@ const logError = (message: string) => {
 export const getParentWindowOrigin = () => {
   if ("ancestorOrigins" in location) {
     return location.ancestorOrigins[0];
+  } else if (document.referrer) {
+    return new URL(document.referrer).origin;
   }
-
-  return new URL(document.referrer).origin;
 };
 
 export const createPostMessageBus = (


### PR DESCRIPTION
If there is no document.referrer (meaning we are in the top frame), the URL constructor will error out. This allows us to gracefully ignore a missing referrer.

This is a follow-up to #21.