### PR TITLE
feat(@meso-network/meso-js): :sparkles: introduce authenticationStrategy configuration option

### DIFF
--- a/.changeset/clean-guests-work.md
+++ b/.changeset/clean-guests-work.md
@@ -1,0 +1,14 @@
+---
+"@meso-network/meso-js": patch
+"@meso-network/types": patch
+"@meso-network/post-message-bus": patch
+---
+
+Deprecate `headlessSignature` in favor of `authenticationStrategy` which introduces:
+
+- `WALLET_VERIFICATION` – Requires the user to sign a message with their wallet
+  before engaging in a transfer
+- `HEADLESS_WALLET_VERIFICATION` – Requires an app (such as an embedded wallet)
+  to sign a message on behalf of the user
+- `NO_WALLET_VERIFICATION` – Requires no wallet signing for the transfer. This
+  is typically used for pre-deployed smart contract wallets

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -463,8 +463,8 @@ message signing yourself in the background.
 
 In the case where pre-deployment smart contract wallets are being used and
 wallet verification cannot be performed, you can skip wallet verification
-altogether and rely on Meso's two-factor authentication and email/password
-mechanisms.
+altogether and rely on Meso's other authentication mechanisms (such as
+two-factor auth).
 
 <details>
   <summary><strong>Example</strong></summary>

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -393,7 +393,7 @@ type Layout = {
 enum AuthenticationStrategy {
   WALLET_VERIFICATION = "wallet_verification",
   HEADLESS_WALLET_VERIFICATION = "headless_wallet_verification",
-  BYPASS_WALLET_VERIFICATION = "BYPASS_WALLET_VERIFICATION",
+  BYPASS_WALLET_VERIFICATION = "bypass_wallet_verification",
 }
 ```
 

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -33,7 +33,7 @@ used in a vanilla JavaScript application as well.
     - [Authentication Strategies](#authentication-strategies)
       - [Wallet verification](#wallet-verification)
       - [Headless wallet verification](#headless-wallet-verification)
-      - [Skip wallet verification](#skip-wallet-verification)
+      - [Bypass wallet verification](#bypass-wallet-verification)
     - [Customizing the layout](#customizing-the-layout)
       - [Position](#position)
       - [Offset](#offset)
@@ -393,7 +393,7 @@ type Layout = {
 enum AuthenticationStrategy {
   WALLET_VERIFICATION = "wallet_verification",
   HEADLESS_WALLET_VERIFICATION = "headless_wallet_verification",
-  NO_WALLET_VERIFICATION = "no_wallet_verification",
+  BYPASS_WALLET_VERIFICATION = "BYPASS_WALLET_VERIFICATION",
 }
 ```
 
@@ -459,7 +459,7 @@ message signing yourself in the background.
 
 </details>
 
-#### Skip wallet verification
+#### Bypass wallet verification
 
 In the case where pre-deployment smart contract wallets are being used and
 wallet verification cannot be performed, you can skip wallet verification
@@ -472,7 +472,7 @@ mechanisms.
 ```ts
 {
   // ...
-  authenticationStrategy: AuthenticationStrategy.NO_WALLET_VERIFICATION,
+  authenticationStrategy: AuthenticationStrategy.BYPASS_WALLET_VERIFICATION,
 }
 ```
 

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -34,7 +34,7 @@ export const transfer = ({
   partnerId,
   layout = DEFAULT_LAYOUT,
   headlessSignature = false,
-  authenticationStrategy = AuthenticationStrategy.WALLET_SIGNATURE,
+  authenticationStrategy = AuthenticationStrategy.WALLET_VERIFICATION,
   onSignMessageRequest,
   onEvent,
 }: TransferConfiguration): TransferInstance => {

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -4,6 +4,7 @@ import {
   TransferConfiguration,
   Position,
   Layout,
+  AuthenticationStrategy,
 } from "@meso-network/types";
 import { validateTransferConfiguration } from "./validateTransferConfiguration";
 import { setupBus } from "./bus";
@@ -33,6 +34,7 @@ export const transfer = ({
   partnerId,
   layout = DEFAULT_LAYOUT,
   headlessSignature = false,
+  authenticationStrategy = AuthenticationStrategy.WALLET_SIGNATURE,
   onSignMessageRequest,
   onEvent,
 }: TransferConfiguration): TransferInstance => {
@@ -66,6 +68,7 @@ export const transfer = ({
         : JSON.stringify(mergedLayout.offset),
     headlessSignature: headlessSignature.toString(),
     version,
+    authenticationStrategy,
   });
   const bus = setupBus(apiHost, frame, onSignMessageRequest, onEvent);
 

--- a/packages/meso-js/test/factories/index.ts
+++ b/packages/meso-js/test/factories/index.ts
@@ -1,0 +1,30 @@
+import {
+  Asset,
+  AuthenticationStrategy,
+  Network,
+  Position,
+  SerializedTransferIframeParams,
+} from "@meso-network/types";
+
+export const serializedTransferIframeParamsFactory: {
+  build: (
+    overrides?: Partial<SerializedTransferIframeParams>,
+  ) => SerializedTransferIframeParams;
+} = {
+  build(overrides = {}) {
+    return {
+      partnerId: "partnerId",
+      network: Network.ETHEREUM_MAINNET,
+      walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      sourceAmount: "100",
+      destinationAsset: Asset.ETH,
+      headlessSignature: "false",
+      layoutPosition: Position.TOP_RIGHT,
+      layoutOffset: "0",
+      version: "1.0.0",
+      authenticationStrategy:
+        AuthenticationStrategy.HEADLESS_WALLET_VERIFICATION,
+      ...overrides,
+    };
+  },
+};

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -1,5 +1,6 @@
 import {
   Asset,
+  AuthenticationStrategy,
   Network,
   Position,
   SerializedTransferIframeParams,
@@ -19,6 +20,7 @@ describe("setupFrame", () => {
     layoutPosition: Position.TOP_RIGHT,
     layoutOffset: "0",
     version: "1.0.0",
+    authenticationStrategy: AuthenticationStrategy.HEADLESS_WALLET_SIGNATURE,
   };
 
   var setupFrameRes: ReturnType<typeof setupFrame>;

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -1,51 +1,97 @@
-import {
-  Asset,
-  AuthenticationStrategy,
-  Network,
-  Position,
-  SerializedTransferIframeParams,
-} from "@meso-network/types";
 import { setupFrame } from "../src/frame";
 import "@testing-library/jest-dom/vitest";
+import { serializedTransferIframeParamsFactory } from "./factories";
+import { AuthenticationStrategy } from "@meso-network/post-message-bus";
 
 describe("setupFrame", () => {
   const apiHost = "https://api.sandbox.meso.network";
-  const params: SerializedTransferIframeParams = {
-    partnerId: "partnerId",
-    network: Network.ETHEREUM_MAINNET,
-    walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-    sourceAmount: "100",
-    destinationAsset: Asset.ETH,
-    headlessSignature: "false",
-    layoutPosition: Position.TOP_RIGHT,
-    layoutOffset: "0",
-    version: "1.0.0",
-    authenticationStrategy: AuthenticationStrategy.HEADLESS_WALLET_SIGNATURE,
-  };
 
-  var setupFrameRes: ReturnType<typeof setupFrame>;
-  beforeEach(() => {
-    setupFrameRes = setupFrame(apiHost, params);
+  describe("encodes", () => {
+    test("configuration as query params", () => {
+      const setupFrameRes = setupFrame(
+        apiHost,
+        serializedTransferIframeParamsFactory.build(),
+      );
+      const params = Object.fromEntries(
+        new URLSearchParams(new URL(setupFrameRes.element.src).search),
+      );
+      expect(params).toMatchInlineSnapshot(`
+      {
+        "authenticationStrategy": "headless_wallet_verification",
+        "destinationAsset": "ETH",
+        "headlessSignature": "false",
+        "layoutOffset": "0",
+        "layoutPosition": "top-right",
+        "network": "eip155:1",
+        "partnerId": "partnerId",
+        "sourceAmount": "100",
+        "version": "1.0.0",
+        "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      }
+    `);
+    });
+
+    test.each([
+      [
+        "headless",
+        serializedTransferIframeParamsFactory.build(),
+        AuthenticationStrategy.HEADLESS_WALLET_VERIFICATION,
+      ],
+      [
+        "wallet verification",
+        serializedTransferIframeParamsFactory.build({
+          authenticationStrategy: AuthenticationStrategy.WALLET_VERIFICATION,
+        }),
+        AuthenticationStrategy.WALLET_VERIFICATION,
+      ],
+      [
+        "bypass wallet verification",
+        serializedTransferIframeParamsFactory.build({
+          authenticationStrategy:
+            AuthenticationStrategy.BYPASS_WALLET_VERIFICATION,
+        }),
+        AuthenticationStrategy.BYPASS_WALLET_VERIFICATION,
+      ],
+    ])("authentication strategy (%s)", async (_, params, value) => {
+      const setupFrameRes = setupFrame(apiHost, params);
+      const searchParams = new URLSearchParams(
+        new URL(setupFrameRes.element.src).search,
+      );
+
+      expect(searchParams.get("authenticationStrategy")).toEqual(value);
+    });
   });
 
   test("creates iframe element in document", () => {
+    const setupFrameRes = setupFrame(
+      apiHost,
+      serializedTransferIframeParamsFactory.build(),
+    );
     expect(setupFrameRes.element).toBeInTheDocument();
     expect(setupFrameRes.element.attributes).toMatchInlineSnapshot(`
       NamedNodeMap {
         "allowtransparency": "true",
-        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&headlessSignature=false&layoutPosition=top-right&layoutOffset=0&version=1.0.0",
+        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&headlessSignature=false&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification",
         "style": "position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 9999; box-sizing: border-box; background-color: transparent;",
       }
     `);
   });
 
   test("invoking remove callback removes iframe from document", () => {
+    const setupFrameRes = setupFrame(
+      apiHost,
+      serializedTransferIframeParamsFactory.build(),
+    );
     expect(setupFrameRes.element).toBeInTheDocument();
     setupFrameRes.remove();
     expect(setupFrameRes.element).not.toBeInTheDocument();
   });
 
   test("invoking hide callback updates styles to hide element", () => {
+    const setupFrameRes = setupFrame(
+      apiHost,
+      serializedTransferIframeParamsFactory.build(),
+    );
     var style = setupFrameRes.element.style;
     expect(style.display).toBe("");
     expect(style.zIndex).toBe("9999");

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -6,7 +6,6 @@ import {
 } from "@meso-network/types";
 import { Mock } from "vitest";
 import { transfer } from "../src";
-import { version } from "../package.json";
 import { DEFAULT_LAYOUT } from "../src/transfer";
 
 var validateTransferConfigurationMock: Mock;

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -7,6 +7,7 @@ import {
 import { Mock } from "vitest";
 import { transfer } from "../src";
 import { DEFAULT_LAYOUT } from "../src/transfer";
+import { version } from "../package.json";
 
 var validateTransferConfigurationMock: Mock;
 vi.mock("../src/validateTransferConfiguration", async () => {
@@ -61,23 +62,27 @@ describe("transfer", () => {
 
     const { destroy } = transfer(configuration);
     expect(setupFrameMock).toHaveBeenCalledOnce();
-    expect(setupFrameMock.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        "https://api.sandbox.meso.network",
-        {
-          "authenticationStrategy": "wallet_verification",
-          "destinationAsset": "ETH",
-          "headlessSignature": "false",
-          "layoutOffset": "0",
-          "layoutPosition": "top-right",
-          "network": "eip155:1",
-          "partnerId": "partnerId",
-          "sourceAmount": "100",
-          "version": "0.0.70",
-          "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        },
-      ]
-    `);
+    expect(setupFrameMock.mock.lastCall[0]).toMatchInlineSnapshot(
+      '"https://api.sandbox.meso.network"',
+    );
+    expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
+      { version: expect.any(String) },
+      `
+      {
+        "authenticationStrategy": "wallet_verification",
+        "destinationAsset": "ETH",
+        "headlessSignature": "false",
+        "layoutOffset": "0",
+        "layoutPosition": "top-right",
+        "network": "eip155:1",
+        "partnerId": "partnerId",
+        "sourceAmount": "100",
+        "version": Any<String>,
+        "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      }
+    `,
+    );
+    expect(setupFrameMock.mock.lastCall[1].version).toEqual(version);
     expect(setupBusMock).toHaveBeenCalledOnce();
     expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`
       [

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -66,6 +66,7 @@ describe("transfer", () => {
       [
         "https://api.sandbox.meso.network",
         {
+          "authenticationStrategy": "wallet_verification",
           "destinationAsset": "ETH",
           "headlessSignature": "false",
           "layoutOffset": "0",
@@ -73,7 +74,7 @@ describe("transfer", () => {
           "network": "eip155:1",
           "partnerId": "partnerId",
           "sourceAmount": "100",
-          "version": "${version}",
+          "version": "0.0.70",
           "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         },
       ]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -266,12 +266,11 @@ export enum AuthenticationStrategy {
   /** Verify wallet by signing a message.
    *
    * New users and returning users with new wallets will still need to perform 2FA and login with email/password.
-   *
    **/
   WALLET_VERIFICATION = "wallet_verification",
   /** Verify a wallet by signing a message in the background _without_ prompting the user. This is useful for scenarios such as embedded wallets.
    *
-   * New users and returning users with new wallets will still need to perform 2FA and login with email/password.
+   * New users and returning users with new wallets will still need to perform login and 2FA.
    */
   HEADLESS_WALLET_VERIFICATION = "headless_wallet_verification",
   /** Bypass wallet signing altogether and rely only on email/password and 2FA.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -237,8 +237,18 @@ export type TransferConfiguration = Readonly<{
   /**
    * Perform message signing in the background without prompting the user. This
    * is useful for embedded wallets.
+   *
+   * @deprecated `headlessSignature` will be removed in a future version. Instead, use {@link TransferConfiguration.authenticationStrategy|authenticationStrategy}.
    */
   headlessSignature?: boolean;
+  /**
+   * Determines the authentication mechanism for users to perform a transfer.
+   *
+   * In all scenarios, the user will still be required to perform two-factor authentication (2FA) and, in some cases provide email/password.
+   *
+   * If omitted, this will default to {@link AuthenticationStrategy.WALLET_VERIFICATION|WALLET_VERIFICATION}.
+   */
+  authenticationStrategy?: AuthenticationStrategy;
   /**
    * A handler to notify you when a message needs to be signed.
    */
@@ -248,6 +258,28 @@ export type TransferConfiguration = Readonly<{
    */
   onEvent: (event: MesoEvent) => void;
 }>;
+
+/**
+ * Used to determine the type of authentication the user will need to perform for a transfer.
+ */
+export enum AuthenticationStrategy {
+  /** Verify wallet by signing a message.
+   *
+   * New users and returning users with new wallets will still need to perform 2FA and login with email/password.
+   *
+   **/
+  WALLET_VERIFICATION = "wallet_verification",
+  /** Verify a wallet by signing a message in the background _without_ prompting the user. This is useful for scenarios such as embedded wallets.
+   *
+   * New users and returning users with new wallets will still need to perform 2FA and login with email/password.
+   */
+  HEADLESS_WALLET_VERIFICATION = "headless_wallet_verification",
+  /** Bypass wallet signing altogether and rely only on email/password and 2FA.
+   *
+   * This is useful for cases where pre-deployment smart contract wallets are being used and wallet verification cannot be performed.
+   */
+  NO_WALLET_VERIFICATION = "no_wallet_verification",
+}
 
 /**
  * Configuration that will be serialized to query params for the Transfer App.
@@ -260,6 +292,7 @@ export type TransferIframeParams = Pick<
   | "sourceAmount"
   | "destinationAsset"
   | "headlessSignature"
+  | "authenticationStrategy"
 > & {
   layoutPosition: NonNullable<Layout["position"]>;
   layoutOffset: NonNullable<Layout["offset"]>;
@@ -271,15 +304,7 @@ export type TransferIframeParams = Pick<
  * The serialized configuration sent to the Transfer App as a query string.
  */
 export type SerializedTransferIframeParams = Record<
-  | "partnerId"
-  | "network"
-  | "walletAddress"
-  | "sourceAmount"
-  | "destinationAsset"
-  | "layoutPosition"
-  | "layoutOffset"
-  | "headlessSignature"
-  | "version",
+  keyof TransferIframeParams,
   string
 >;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -278,7 +278,7 @@ export enum AuthenticationStrategy {
    *
    * This is useful for cases where pre-deployment smart contract wallets are being used and wallet verification cannot be performed.
    */
-  NO_WALLET_VERIFICATION = "no_wallet_verification",
+  BYPASS_WALLET_VERIFICATION = "bypass_wallet_verification",
 }
 
 /**


### PR DESCRIPTION
This deprecates `headlessSignature` in favor of a new configuration parameter – `authenticationStrategy`.

The `authenticationStrategy` allows the following values:

- `WALLET_VERIFICATION` – Requires the user to sign a message with their wallet before engaging in a transfer
- `HEADLESS_WALLET_VERIFICATION` – Requires an app (such as an embedded wallet) to sign a message on behalf of the user
- `NO_WALLET_VERIFICATION` – Requires no wallet signing for the transfer. This is typically used for pre-deployed smart contract wallets

After the rollout, we will fully remove `headlessSignature` in a future version.