### PR TITLE
feat(@meso-network/meso-js): export createPostMessageBus

### DIFF
--- a/.changeset/khaki-ladybugs-work.md
+++ b/.changeset/khaki-ladybugs-work.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Expose `createPostMessageBus`

--- a/packages/meso-js/src/index.ts
+++ b/packages/meso-js/src/index.ts
@@ -3,4 +3,5 @@ import { version } from "../package.json";
 export * from "./types";
 export { transfer } from "./transfer";
 export { validateLayout } from "./validateLayout";
+export { createPostMessageBus } from "./createPostMessageBus";
 export const MESO_JS_VERSION = version;


### PR DESCRIPTION
As a follow-up to #29, this ensures `createPostMessageBus` is exported for use within transfers.