### PR TITLE
fix(@meso-network/meso-js): 🐛 guard against checking unreadable iframes

### DIFF
--- a/.changeset/nice-walls-rescue.md
+++ b/.changeset/nice-walls-rescue.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Guard against unreadable iframe `src` attributes

--- a/packages/meso-js/src/createPostMessageBus.ts
+++ b/packages/meso-js/src/createPostMessageBus.ts
@@ -46,9 +46,14 @@ export const createPostMessageBus = (
   } else {
     // otherwise, find child iframe with matching origin
     const frames = Array.from(document.querySelectorAll("iframe"));
-    const frameWindow = frames.find(
-      (frame) => new URL(frame.src).origin === targetOrigin,
-    );
+    const frameWindow = frames.find((frame) => {
+      try {
+        const url = new URL(frame.src);
+        return url.origin === targetOrigin;
+      } catch (err: unknown) {
+        return false;
+      }
+    });
 
     if (!frameWindow) {
       const message = `No iframe found with origin ${targetOrigin}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,6 @@ importers:
         specifier: ^22.1.0
         version: 22.1.0
 
-  packages/types: {}
-
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:


### PR DESCRIPTION
In the case where iframes are on the page and we attempt to read their `src` attribute, our check blows up. This guards against unreadable frame sources.