### PR TITLE
feat(@meso-network/meso-js): 🔥 remove deprecated headlessSignature option in favor of `authenticationStrategy`

### DIFF
--- a/.changeset/sharp-rats-cry.md
+++ b/.changeset/sharp-rats-cry.md
@@ -1,0 +1,8 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Remove `headlessSignature` from configuration options. This had been deprecated
+in
+[v0.0.71](https://github.com/meso-network/meso-js/releases/tag/%40meso-network%2Fmeso-js%400.0.71)
+and is now being fully removed

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -33,7 +33,6 @@ export const transfer = ({
   environment,
   partnerId,
   layout = DEFAULT_LAYOUT,
-  headlessSignature = false,
   authenticationStrategy = AuthenticationStrategy.WALLET_VERIFICATION,
   onSignMessageRequest,
   onEvent,
@@ -47,7 +46,6 @@ export const transfer = ({
     environment,
     partnerId,
     layout: mergedLayout,
-    headlessSignature,
     onSignMessageRequest,
     onEvent,
   };
@@ -66,7 +64,6 @@ export const transfer = ({
       typeof mergedLayout.offset === "string"
         ? mergedLayout.offset
         : JSON.stringify(mergedLayout.offset),
-    headlessSignature: headlessSignature.toString(),
     version,
     authenticationStrategy,
   });

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -235,13 +235,6 @@ export type TransferConfiguration = Readonly<{
    */
   layout?: Layout;
   /**
-   * Perform message signing in the background without prompting the user. This
-   * is useful for embedded wallets.
-   *
-   * @deprecated `headlessSignature` will be removed in a future version. Instead, use {@link TransferConfiguration.authenticationStrategy|authenticationStrategy}.
-   */
-  headlessSignature?: boolean;
-  /**
    * Determines the authentication mechanism for users to perform a transfer.
    *
    * In all scenarios, the user will still be required to perform two-factor authentication (2FA) and, in some cases provide email/password.
@@ -290,7 +283,6 @@ export type TransferIframeParams = Pick<
   | "walletAddress"
   | "sourceAmount"
   | "destinationAsset"
-  | "headlessSignature"
   | "authenticationStrategy"
 > & {
   layoutPosition: NonNullable<Layout["position"]>;

--- a/packages/meso-js/src/validateTransferConfiguration.ts
+++ b/packages/meso-js/src/validateTransferConfiguration.ts
@@ -1,5 +1,6 @@
 import {
   Asset,
+  AuthenticationStrategy,
   Environment,
   EventKind,
   Network,
@@ -21,9 +22,9 @@ export const validateTransferConfiguration = ({
   environment,
   partnerId,
   layout,
-  headlessSignature,
   onSignMessageRequest,
   onEvent,
+  authenticationStrategy,
 }: TransferConfiguration): boolean => {
   if (typeof onEvent !== "function") {
     throw new Error("[meso-js] An onEvent callback is required.");
@@ -94,11 +95,18 @@ export const validateTransferConfiguration = ({
       payload: { error: { message: `"partnerId" must be provided.` } },
     });
     return false;
-  } else if (typeof headlessSignature !== "boolean") {
+  } else if (
+    authenticationStrategy &&
+    !Object.values(AuthenticationStrategy).includes(authenticationStrategy)
+  ) {
     onEvent({
       kind: EventKind.CONFIGURATION_ERROR,
       payload: {
-        error: { message: '"headlessSignature" must be a boolean.' },
+        error: {
+          message: `\`authenticationStrategy\` must be one of ${Object.values(
+            AuthenticationStrategy,
+          ).join(", ")}`,
+        },
       },
     });
     return false;

--- a/packages/meso-js/test/factories/index.ts
+++ b/packages/meso-js/test/factories/index.ts
@@ -18,7 +18,6 @@ export const serializedTransferIframeParamsFactory: {
       walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       sourceAmount: "100",
       destinationAsset: Asset.ETH,
-      headlessSignature: "false",
       layoutPosition: Position.TOP_RIGHT,
       layoutOffset: "0",
       version: "1.0.0",

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -16,19 +16,18 @@ describe("setupFrame", () => {
         new URLSearchParams(new URL(setupFrameRes.element.src).search),
       );
       expect(params).toMatchInlineSnapshot(`
-      {
-        "authenticationStrategy": "headless_wallet_verification",
-        "destinationAsset": "ETH",
-        "headlessSignature": "false",
-        "layoutOffset": "0",
-        "layoutPosition": "top-right",
-        "network": "eip155:1",
-        "partnerId": "partnerId",
-        "sourceAmount": "100",
-        "version": "1.0.0",
-        "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-      }
-    `);
+        {
+          "authenticationStrategy": "headless_wallet_verification",
+          "destinationAsset": "ETH",
+          "layoutOffset": "0",
+          "layoutPosition": "top-right",
+          "network": "eip155:1",
+          "partnerId": "partnerId",
+          "sourceAmount": "100",
+          "version": "1.0.0",
+          "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        }
+      `);
     });
 
     test.each([
@@ -71,7 +70,7 @@ describe("setupFrame", () => {
     expect(setupFrameRes.element.attributes).toMatchInlineSnapshot(`
       NamedNodeMap {
         "allowtransparency": "true",
-        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&headlessSignature=false&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification",
+        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification",
         "style": "position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 9999; box-sizing: border-box; background-color: transparent;",
       }
     `);

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -39,7 +39,6 @@ describe("transfer", () => {
     destinationAsset: Asset.ETH,
     environment: Environment.SANDBOX,
     partnerId: "partnerId",
-    headlessSignature: false,
     layout: DEFAULT_LAYOUT,
     onSignMessageRequest: vi.fn(),
     onEvent: vi.fn(),
@@ -71,7 +70,6 @@ describe("transfer", () => {
       {
         "authenticationStrategy": "wallet_verification",
         "destinationAsset": "ETH",
-        "headlessSignature": "false",
         "layoutOffset": "0",
         "layoutPosition": "top-right",
         "network": "eip155:1",

--- a/packages/meso-js/test/validateTransferConfiguration.test.ts
+++ b/packages/meso-js/test/validateTransferConfiguration.test.ts
@@ -279,7 +279,7 @@ describe("validateTransferConfiguration", () => {
     `);
   });
 
-  test("non-boolean headlessSignature emits", () => {
+  test("invalid authenticationStrategy emits", () => {
     expect(
       validateTransferConfiguration({
         onEvent,
@@ -289,8 +289,9 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        // @ts-expect-error: Bypass type system to simulate runtime behavior
-        headlessSignature: "false",
+        onSignMessageRequest: vi.fn(),
+        // @ts-expect-error: Bypassing types for testing
+        authenticationStrategy: "foo",
       }),
     ).toBe(false);
     expect(onEvent).toHaveBeenCalledOnce();
@@ -300,7 +301,37 @@ describe("validateTransferConfiguration", () => {
           "kind": "CONFIGURATION_ERROR",
           "payload": {
             "error": {
-              "message": "\\"headlessSignature\\" must be a boolean.",
+              "message": "\`authenticationStrategy\` must be one of wallet_verification, headless_wallet_verification, bypass_wallet_verification",
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  test("empty authenticationStrategy emits", () => {
+    expect(
+      validateTransferConfiguration({
+        onEvent,
+        sourceAmount: "1",
+        network: Network.ETHEREUM_MAINNET,
+        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        destinationAsset: Asset.ETH,
+        environment: Environment.SANDBOX,
+        partnerId: "meso-js-test",
+        onSignMessageRequest: vi.fn(),
+        // @ts-expect-error: Bypassing types for testing
+        authenticationStrategy: " ",
+      }),
+    ).toBe(false);
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "CONFIGURATION_ERROR",
+          "payload": {
+            "error": {
+              "message": "\`authenticationStrategy\` must be one of wallet_verification, headless_wallet_verification, bypass_wallet_verification",
             },
           },
         },
@@ -318,7 +349,6 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        headlessSignature: false,
         // @ts-expect-error: Bypass type system to simulate runtime behavior
         onSignMessageRequest: "signedMessage",
       }),
@@ -350,7 +380,6 @@ describe("validateTransferConfiguration", () => {
           destinationAsset: Asset.ETH,
           environment: Environment.SANDBOX,
           partnerId: "meso-js-test",
-          headlessSignature: false,
           // @ts-expect-error: Bypass type system to simulate runtime behavior
           layout: { position: "bottom-center" },
         }),
@@ -383,7 +412,6 @@ describe("validateTransferConfiguration", () => {
           destinationAsset: Asset.ETH,
           environment: Environment.SANDBOX,
           partnerId: "meso-js-test",
-          headlessSignature: false,
         };
       });
 
@@ -598,7 +626,6 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        headlessSignature: false,
         onSignMessageRequest: vi.fn(),
       });
       expect(onEvent).not.toHaveBeenCalled();
@@ -614,7 +641,6 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        headlessSignature: false,
         layout: { offset: "0" },
         onSignMessageRequest: vi.fn(),
       });
@@ -631,7 +657,6 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        headlessSignature: false,
         layout: { position: Position.TOP_RIGHT, offset: "0" },
         onSignMessageRequest: vi.fn(),
       });
@@ -648,7 +673,6 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        headlessSignature: false,
         layout: { position: Position.TOP_RIGHT, offset: "0" },
         onSignMessageRequest: vi.fn(),
       });
@@ -665,7 +689,6 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        headlessSignature: false,
         layout: { position: Position.TOP_RIGHT, offset: { horizontal: "10" } },
         onSignMessageRequest: vi.fn(),
       });
@@ -682,7 +705,6 @@ describe("validateTransferConfiguration", () => {
         destinationAsset: Asset.ETH,
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
-        headlessSignature: false,
         layout: {
           position: Position.TOP_RIGHT,
           offset: { horizontal: "10", vertical: "22" },


### PR DESCRIPTION
This is a follow up to https://github.com/meso-network/meso-js/pull/25.