### PR TITLE
feat(@meso-network/meso-js): ✨ add color-scheme style attribute to iframe by default

### DIFF
--- a/.changeset/pink-planets-clap.md
+++ b/.changeset/pink-planets-clap.md
@@ -1,0 +1,8 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Set
+[`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme)
+to `auto` by default on rendered iframe to ensure the Meso experience respects
+embedding application color overrides.

--- a/packages/meso-js/src/frame.ts
+++ b/packages/meso-js/src/frame.ts
@@ -30,6 +30,7 @@ const injectFullScreenIframe = (src: string) => {
   iframe.style.border = "none";
   iframe.style.boxSizing = "border-box";
   iframe.style.backgroundColor = "transparent";
+  iframe.style.colorScheme = "auto";
 
   document.body.appendChild(iframe);
 

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -71,7 +71,7 @@ describe("setupFrame", () => {
       NamedNodeMap {
         "allowtransparency": "true",
         "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification",
-        "style": "position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 9999; box-sizing: border-box; background-color: transparent;",
+        "style": "position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 9999; box-sizing: border-box; background-color: transparent; color-scheme: auto;",
       }
     `);
   });


### PR DESCRIPTION
This allows the meso iframe to render the correct background color(s) when the embedding page overrides the os/browser level color scheme.
