### PR TITLE
feat(@meso-network/meso-js): ⚡ extend message bus to accept webview window references

### DIFF
--- a/.changeset/breezy-poets-lay.md
+++ b/.changeset/breezy-poets-lay.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Introduce `mode` to transfer configuration to support operating in webviews within native mobile apps.

--- a/packages/meso-js/src/createPostMessageBus.ts
+++ b/packages/meso-js/src/createPostMessageBus.ts
@@ -57,12 +57,12 @@ export const createPostMessageBus = (
   }
 
   let postMessageWindow: Window;
-  if (getParentWindowOrigin() === targetOrigin) {
-    // target is parent, currently in iframe
-    postMessageWindow = window.parent;
-  } else if (syntheticWindowMessageHandle) {
+  if (syntheticWindowMessageHandle) {
     // If we are given a custom window handler (for mobile webviews), use that.
     postMessageWindow = syntheticWindowMessageHandle;
+  } else if (getParentWindowOrigin() === targetOrigin) {
+    // target is parent, currently in iframe
+    postMessageWindow = window.parent;
   } else {
     // otherwise, find child iframe with matching origin
     const frames = Array.from(document.querySelectorAll("iframe"));

--- a/packages/meso-js/src/parseMessage.ts
+++ b/packages/meso-js/src/parseMessage.ts
@@ -1,0 +1,36 @@
+import { Result, err, ok } from "./result";
+import { Message } from "./types";
+import { validateMessage } from "./validators";
+
+/**
+ * Convert a received message into an object (if necessary) and validate it's structure.
+ *
+ * Messages received in some environments such as mobile applications with webviews will be stringified.
+ */
+export const parseMessage = (
+  data: string | object,
+): Result<Message, string> => {
+  let parsedMessage = data;
+
+  if (typeof data === "string") {
+    if (data.trim().startsWith("{")) {
+      try {
+        parsedMessage = JSON.parse(data);
+      } catch (error: unknown) {
+        return err(
+          "Unable to deserialize message into JSON (error occurred during parsing).",
+        );
+      }
+    } else {
+      return err(
+        "Unable to deserialize message into JSON (source is not a JSON string).",
+      );
+    }
+  }
+
+  if (!validateMessage(parsedMessage as Message)) {
+    return err("Invalid message.");
+  }
+
+  return ok(parsedMessage as Message);
+};

--- a/packages/meso-js/src/result.ts
+++ b/packages/meso-js/src/result.ts
@@ -1,0 +1,10 @@
+// Based off of: https://www.huy.rocks/everyday/02-14-2022-typescript-implement-rust-style-result
+export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+export const ok = <T>(data: T): Result<T, never> => {
+  return { ok: true, value: data };
+};
+
+export const err = <E>(error: E): Result<never, E> => {
+  return { ok: false, error };
+};

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -9,6 +9,7 @@ import {
   TransferConfiguration,
   TransferInstance,
   Environment,
+  TransferExperienceMode,
 } from "./types";
 
 const apiHosts: { readonly [key in Environment]: string } = {
@@ -66,6 +67,7 @@ export const transfer = ({
         : JSON.stringify(mergedLayout.offset),
     version,
     authenticationStrategy,
+    mode: TransferExperienceMode.EMBEDDED,
   });
   const bus = setupBus(apiHost, frame, onSignMessageRequest, onEvent);
 

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -290,6 +290,8 @@ export type TransferIframeParams = Pick<
   layoutOffset: NonNullable<Layout["offset"]>;
   /** The version of meso-js. */
   version: string;
+  /** The mode for the rendering context of the Meso experience. */
+  mode: TransferExperienceMode;
 };
 
 /**
@@ -299,6 +301,20 @@ export type SerializedTransferIframeParams = Record<
   keyof TransferIframeParams,
   string
 >;
+
+/**
+ * The mode for the rendering context of the Meso experience.
+ */
+export enum TransferExperienceMode {
+  /**
+   * Intended to run inside an iframe in a web browser.
+   */
+  EMBEDDED = "embedded",
+  /**
+   * Intended to run inside a webview in a native mobile app.
+   */
+  WEBVIEW = "webview",
+}
 
 /**
  * The handler to the instance returned when calling `transfer()`.
@@ -422,6 +438,11 @@ export type PostMessageBus = {
    */
   destroy: () => void;
 };
+
+/**
+ * A handler function for a message event.
+ */
+export type HandlerFn = Parameters<PostMessageBus["on"]>[1];
 
 /**
  * A structured error returned when the post message bus cannot be initialized.

--- a/packages/meso-js/test/createPostMessageBus.test.ts
+++ b/packages/meso-js/test/createPostMessageBus.test.ts
@@ -36,6 +36,20 @@ describe("createPostMessageBus", () => {
     });
   });
 
+  describe("in webview", () => {
+    test("returns a post message bus instance for valid target origin", () => {
+      const fakeWindow = {} as Window;
+      expect(createPostMessageBus(PARTNER_APP_ORIGIN, fakeWindow))
+        .toMatchInlineSnapshot(`
+      {
+        "destroy": [Function],
+        "emit": [Function],
+        "on": [Function],
+      }
+    `);
+    });
+  });
+
   describe("in parent frame", () => {
     afterEach(() => {
       [...document.querySelectorAll("iframe")].forEach((frame) => {

--- a/packages/meso-js/test/factories/index.ts
+++ b/packages/meso-js/test/factories/index.ts
@@ -4,6 +4,7 @@ import {
   Network,
   Position,
   SerializedTransferIframeParams,
+  TransferExperienceMode,
 } from "../../src/types";
 
 export const serializedTransferIframeParamsFactory: {
@@ -23,6 +24,7 @@ export const serializedTransferIframeParamsFactory: {
       version: "1.0.0",
       authenticationStrategy:
         AuthenticationStrategy.HEADLESS_WALLET_VERIFICATION,
+      mode: TransferExperienceMode.EMBEDDED,
       ...overrides,
     };
   },

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -21,6 +21,7 @@ describe("setupFrame", () => {
           "destinationAsset": "ETH",
           "layoutOffset": "0",
           "layoutPosition": "top-right",
+          "mode": "embedded",
           "network": "eip155:1",
           "partnerId": "partnerId",
           "sourceAmount": "100",
@@ -70,7 +71,7 @@ describe("setupFrame", () => {
     expect(setupFrameRes.element.attributes).toMatchInlineSnapshot(`
       NamedNodeMap {
         "allowtransparency": "true",
-        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification",
+        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification&mode=embedded",
         "style": "position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 9999; box-sizing: border-box; background-color: transparent; color-scheme: auto;",
       }
     `);

--- a/packages/meso-js/test/parseMessage.test.ts
+++ b/packages/meso-js/test/parseMessage.test.ts
@@ -91,7 +91,9 @@ describe("parseMessage", () => {
         throw new Error("Test failed");
       }
 
-      expect(result.error).toMatchInlineSnapshot('"Unable to deserialize message into JSON (error occurred during parsing)."');
+      expect(result.error).toMatchInlineSnapshot(
+        '"Unable to deserialize message into JSON (error occurred during parsing)."',
+      );
     });
   });
 });

--- a/packages/meso-js/test/parseMessage.test.ts
+++ b/packages/meso-js/test/parseMessage.test.ts
@@ -1,0 +1,97 @@
+import { MessageKind } from "../src";
+import { parseMessage } from "../src/parseMessage";
+
+describe("parseMessage", () => {
+  describe("success", () => {
+    test("returns message when properly structured", () => {
+      const result = parseMessage({
+        kind: MessageKind.ERROR,
+        payload: { message: "err" },
+      });
+
+      if (!result.ok) {
+        throw new Error("Fail");
+      }
+
+      expect(result.value).toMatchInlineSnapshot(`
+        {
+          "kind": "ERROR",
+          "payload": {
+            "message": "err",
+          },
+        }
+      `);
+    });
+
+    test("returns message when properly structured (stringified)", () => {
+      const result = parseMessage(
+        JSON.stringify({
+          kind: MessageKind.ERROR,
+          payload: { message: "err" },
+        }),
+      );
+
+      if (!result.ok) {
+        throw new Error("Fail");
+      }
+
+      expect(result.value).toMatchInlineSnapshot(`
+        {
+          "kind": "ERROR",
+          "payload": {
+            "message": "err",
+          },
+        }
+      `);
+    });
+  });
+
+  describe("failure", () => {
+    test("returns error for invalid structure", () => {
+      const result = parseMessage({ foo: "bar" });
+
+      if (result.ok) {
+        throw new Error("Test failed");
+      }
+
+      expect(result.error).toMatchInlineSnapshot('"Invalid message."');
+    });
+
+    test("returns error for invalid structure (stringified)", () => {
+      const result = parseMessage(JSON.stringify({ foo: "bar" }));
+
+      if (result.ok) {
+        throw new Error("Test failed");
+      }
+
+      expect(result.error).toMatchInlineSnapshot('"Invalid message."');
+    });
+
+    test.each([
+      ["number", 22],
+      ["boolean", false],
+      ["string", "foo"],
+      ["invalid object", "}{foo: 22}"],
+    ])("returns error for stringified data (%s)", (_, message) => {
+      const result = parseMessage(JSON.stringify(message));
+
+      if (result.ok) {
+        throw new Error("Test failed");
+      }
+
+      expect(result.error).toBe(
+        "Unable to deserialize message into JSON (source is not a JSON string).",
+      );
+    });
+
+    test("returns error for invalid JSON", () => {
+      const result = parseMessage("{9}");
+
+      if (result.ok) {
+        throw new Error("Test failed");
+      }
+
+      expect(result.error).toMatchInlineSnapshot('"Unable to deserialize message into JSON (error occurred during parsing)."');
+    });
+  });
+});

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -65,21 +65,20 @@ describe("transfer", () => {
       '"https://api.sandbox.meso.network"',
     );
     expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
-      { version: expect.any(String) },
-      `
+      { version: expect.any(String) }, `
       {
         "authenticationStrategy": "wallet_verification",
         "destinationAsset": "ETH",
         "layoutOffset": "0",
         "layoutPosition": "top-right",
+        "mode": "embedded",
         "network": "eip155:1",
         "partnerId": "partnerId",
         "sourceAmount": "100",
         "version": Any<String>,
         "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       }
-    `,
-    );
+    `);
     expect(setupFrameMock.mock.lastCall[1].version).toEqual(version);
     expect(setupBusMock).toHaveBeenCalledOnce();
     expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -65,7 +65,8 @@ describe("transfer", () => {
       '"https://api.sandbox.meso.network"',
     );
     expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
-      { version: expect.any(String) }, `
+      { version: expect.any(String) },
+      `
       {
         "authenticationStrategy": "wallet_verification",
         "destinationAsset": "ETH",
@@ -78,7 +79,8 @@ describe("transfer", () => {
         "version": Any<String>,
         "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       }
-    `);
+    `,
+    );
     expect(setupFrameMock.mock.lastCall[1].version).toEqual(version);
     expect(setupBusMock).toHaveBeenCalledOnce();
     expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`


### PR DESCRIPTION
This allows the Meso experience to operate in the context of native mobile applications via webviews as well as traditional browser iframes.

A new configuration parameter (`mode`) has been introduced. It will default to `embedded`, but also supports a value of `webview`. I am _intentionally_ not documenting this for now (though it is documented in the type system).

This PR updates "postMessageBus" to accept a second argument (a synthetic window) which, if provided, will be used as a target to send messages to from within the Meso experience.

It also adds logic around the handling of messages since we cannot guarantee that they will always be objects. Instead, we parse out the structured objects from strings (if necessary) and then process the message(s).