### PR TITLE
feat(@meso-network/meso-js): ✨ allow post messaging with React Native webview contexts

### DIFF
--- a/.changeset/neat-onions-watch.md
+++ b/.changeset/neat-onions-watch.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Enable post messaging in React Native WebViews.


### PR DESCRIPTION
This introduces additional checks in our post messaging library to see if we are in a WebView context and also check for React Native specific injected `postMessage` capabilities.

The [react-native-webview](https://github.com/react-native-webview/react-native-webview/tree/master) library has a convention of injecting a `window.ReactNativeWebView` namespace into the running application to negotiate post messaging.

In the future, we may find it makes more sense to allow the handle to the `postMessage` function to be passed to us at initialization time, but I think the trade-off of specificity – _for now_ – is acceptable.