### PR TITLE
add support for cash outs

### DIFF
--- a/.changeset/serious-squids-admire.md
+++ b/.changeset/serious-squids-admire.md
@@ -2,4 +2,4 @@
 "@meso-network/meso-js": patch
 ---
 
-add support for cash-out transfers
+Add initial (limited access) support for cash out transfers.

--- a/.changeset/serious-squids-admire.md
+++ b/.changeset/serious-squids-admire.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+add support for cash-out transfers

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build": "pnpm clean && pnpm typecheck && pnpm run --filter @meso-network/meso-js -r build",
     "fmt": "prettier -w .",
     "fmt:check": "prettier --check .",
-    "spelling:check": "cspell ."
+    "spelling:check": "cspell .",
+    "check": "pnpm lint && pnpm typecheck && pnpm fmt:check && pnpm spelling:check && pnpm test"
   },
   "workspaces": [
     "packages/*"

--- a/packages/meso-js/src/bus.ts
+++ b/packages/meso-js/src/bus.ts
@@ -14,6 +14,7 @@ export const setupBus = (
   apiHost: string,
   frame: ReturnType<typeof setupFrame>,
   onSignMessageRequest: TransferConfiguration["onSignMessageRequest"],
+  onSendTransactionRequest: TransferConfiguration["onSendTransactionRequest"],
   onEvent: TransferConfiguration["onEvent"],
 ) => {
   const bus = createPostMessageBus(apiHost);
@@ -33,6 +34,25 @@ export const setupBus = (
         kind: MessageKind.RETURN_SIGNED_MESSAGE_RESULT,
         payload: { signedMessage },
       });
+    }
+  });
+
+  bus.on(MessageKind.REQUEST_SEND_TRANSACTION, async (message) => {
+    if (message.kind === MessageKind.REQUEST_SEND_TRANSACTION) {
+      const {
+        amount,
+        recipientAddress,
+        tokenAddress,
+        decimals,
+        interfaceDefinition,
+      } = message.payload;
+      await onSendTransactionRequest(
+        amount,
+        recipientAddress,
+        tokenAddress,
+        decimals,
+        interfaceDefinition,
+      );
     }
   });
 

--- a/packages/meso-js/src/bus.ts
+++ b/packages/meso-js/src/bus.ts
@@ -43,19 +43,13 @@ export const setupBus = (
       message.kind === MessageKind.REQUEST_SEND_TRANSACTION &&
       onSendTransactionRequest
     ) {
-      const {
-        amount,
-        recipientAddress,
-        tokenAddress,
-        decimals,
-        interfaceDefinition,
-      } = message.payload;
+      const { amount, recipientAddress, tokenAddress, decimals } =
+        message.payload;
       await onSendTransactionRequest(
         amount,
         recipientAddress,
         tokenAddress,
         decimals,
-        interfaceDefinition,
       );
     }
   });

--- a/packages/meso-js/src/bus.ts
+++ b/packages/meso-js/src/bus.ts
@@ -7,15 +7,16 @@ import {
   TransferApprovedPayload,
   TransferCompletePayload,
   TransferConfiguration,
+  CashOutConfiguration,
 } from "./types";
 import { createPostMessageBus } from "./createPostMessageBus";
 
 export const setupBus = (
   apiHost: string,
   frame: ReturnType<typeof setupFrame>,
-  onSignMessageRequest: TransferConfiguration["onSignMessageRequest"],
-  onSendTransactionRequest: TransferConfiguration["onSendTransactionRequest"],
   onEvent: TransferConfiguration["onEvent"],
+  onSignMessageRequest: TransferConfiguration["onSignMessageRequest"],
+  onSendTransactionRequest?: CashOutConfiguration["onSendTransactionRequest"],
 ) => {
   const bus = createPostMessageBus(apiHost);
   if ("message" in bus) {
@@ -38,7 +39,10 @@ export const setupBus = (
   });
 
   bus.on(MessageKind.REQUEST_SEND_TRANSACTION, async (message) => {
-    if (message.kind === MessageKind.REQUEST_SEND_TRANSACTION) {
+    if (
+      message.kind === MessageKind.REQUEST_SEND_TRANSACTION &&
+      onSendTransactionRequest
+    ) {
       const {
         amount,
         recipientAddress,

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -36,6 +36,7 @@ export const transfer = ({
   layout = DEFAULT_LAYOUT,
   authenticationStrategy = AuthenticationStrategy.WALLET_VERIFICATION,
   onSignMessageRequest,
+  onSendTransactionRequest,
   onEvent,
 }: TransferConfiguration): TransferInstance => {
   const mergedLayout = { ...DEFAULT_LAYOUT, ...layout };
@@ -48,6 +49,7 @@ export const transfer = ({
     partnerId,
     layout: mergedLayout,
     onSignMessageRequest,
+    onSendTransactionRequest,
     onEvent,
   };
   if (!validateTransferConfiguration(configuration))
@@ -69,7 +71,7 @@ export const transfer = ({
     authenticationStrategy,
     mode: TransferExperienceMode.EMBEDDED,
   });
-  const bus = setupBus(apiHost, frame, onSignMessageRequest, onEvent);
+  const bus = setupBus(apiHost, frame, onSignMessageRequest, onSendTransactionRequest, onEvent);
 
   return {
     destroy: () => {

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -72,15 +72,13 @@ export const transfer = ({
     };
     if (!validateTransferConfiguration(cashOutConfiguration))
       return NOOP_TRANSFER_INSTANCE;
-  } else if (destinationAsset in CryptoAsset) {
+  } else {
     const cashInConfiguration: CashInConfiguration = {
       ...baseConfiguration,
       destinationAsset: destinationAsset as CryptoAsset,
     };
     if (!validateTransferConfiguration(cashInConfiguration))
       return NOOP_TRANSFER_INSTANCE;
-  } else {
-    return NOOP_TRANSFER_INSTANCE;
   }
 
   const apiHost = apiHosts[environment];

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -40,7 +40,7 @@ export const transfer = ({
   destinationAsset,
   environment,
   partnerId,
-  layout = DEFAULT_LAYOUT, // Assuming DEFAULT_LAYOUT is of type Layout
+  layout = DEFAULT_LAYOUT,
   authenticationStrategy = AuthenticationStrategy.WALLET_VERIFICATION,
   onSignMessageRequest,
   onEvent,

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -2,10 +2,10 @@ import { setupBus } from "./bus";
 import { setupFrame } from "./frame";
 import { version } from "../package.json";
 import {
+  Asset,
   AuthenticationStrategy,
   CashOutConfiguration,
   Environment,
-  FiatAsset,
   Layout,
   Position,
   TransferConfiguration,
@@ -42,7 +42,7 @@ export const transfer = (
     // sourceAsset is only optional in Cash-in case (for backwards compatibility
     // with previous versions), remove when adding support for other FiatAssets
     // and we make sourceAsset required
-    sourceAsset: FiatAsset.USD,
+    sourceAsset: Asset.USD,
 
     ...transferConfiguration,
   };

--- a/packages/meso-js/src/transfer.ts
+++ b/packages/meso-js/src/transfer.ts
@@ -7,14 +7,14 @@ import {
   BaseConfiguration,
   CashInConfiguration,
   CashOutConfiguration,
+  CryptoAsset,
   Environment,
+  FiatAsset,
   Layout,
   Position,
   TransferConfiguration,
   TransferExperienceMode,
   TransferInstance,
-  isCryptoAsset,
-  isFiatAsset,
 } from "./types";
 
 const apiHosts: { readonly [key in Environment]: string } = {
@@ -64,18 +64,18 @@ export const transfer = ({
     onEvent,
   };
 
-  if (isFiatAsset(destinationAsset)) {
+  if (destinationAsset in FiatAsset) {
     const cashOutConfiguration: CashOutConfiguration = {
       ...baseConfiguration,
-      destinationAsset,
+      destinationAsset: destinationAsset as FiatAsset,
       onSendTransactionRequest: onSendTransactionRequest!,
     };
     if (!validateTransferConfiguration(cashOutConfiguration))
       return NOOP_TRANSFER_INSTANCE;
-  } else if (isCryptoAsset(destinationAsset)) {
+  } else if (destinationAsset in CryptoAsset) {
     const cashInConfiguration: CashInConfiguration = {
       ...baseConfiguration,
-      destinationAsset,
+      destinationAsset: destinationAsset as CryptoAsset,
     };
     if (!validateTransferConfiguration(cashInConfiguration))
       return NOOP_TRANSFER_INSTANCE;

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -260,14 +260,22 @@ export type BaseConfiguration = Readonly<{
 
 export type CashInConfiguration = BaseConfiguration & {
   /**
-   * The asset to be transferred.
+   * The fiat asset to be used. Defaults to `FiatAsset.USD`.
+   */
+  sourceAsset?: FiatAsset;
+  /**
+   * The crypto asset to be transferred.
    */
   destinationAsset: CryptoAsset;
 };
 
 export type CashOutConfiguration = BaseConfiguration & {
   /**
-   * The asset to be transferred.
+   * The crypto asset to be transferred.
+   */
+  sourceAsset: CryptoAsset;
+  /**
+   * The fiat asset to be cashed out.
    */
   destinationAsset: FiatAsset;
   /**
@@ -320,6 +328,7 @@ export type TransferIframeParams = Pick<
   | "network"
   | "walletAddress"
   | "sourceAmount"
+  | "sourceAsset"
   | "destinationAsset"
   | "authenticationStrategy"
 > & {

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -117,19 +117,27 @@ export enum Network {
   OP_MAINNET = "eip155:10",
 }
 
-export enum CryptoAsset {
+export enum Asset {
+  // CryptoAsset
   ETH = "ETH",
   SOL = "SOL",
   USDC = "USDC",
   MATIC = "MATIC",
-}
 
-export enum FiatAsset {
+  // FiatAsset
   USD = "USD",
 }
 
-export type Asset = CryptoAsset | FiatAsset;
-export const Asset = { ...CryptoAsset, ...FiatAsset };
+export const CryptoAsset = {
+  [Asset.ETH]: Asset.ETH,
+  [Asset.SOL]: Asset.SOL,
+  [Asset.USDC]: Asset.USDC,
+  [Asset.MATIC]: Asset.MATIC,
+} as const;
+
+export const FiatAsset = {
+  [Asset.USD]: Asset.USD,
+} as const;
 
 /**
  * A stringified number representing an amount of USD.
@@ -260,24 +268,24 @@ export type BaseConfiguration = Readonly<{
 
 export type CashInConfiguration = BaseConfiguration & {
   /**
-   * The fiat asset to be used. Defaults to `FiatAsset.USD`.
+   * The fiat asset to be used. Defaults to `Asset.USD`.
    */
-  sourceAsset?: FiatAsset;
+  sourceAsset?: keyof typeof FiatAsset;
   /**
    * The crypto asset to be transferred.
    */
-  destinationAsset: CryptoAsset;
+  destinationAsset: keyof typeof CryptoAsset;
 };
 
 export type CashOutConfiguration = BaseConfiguration & {
   /**
    * The crypto asset to be transferred.
    */
-  sourceAsset: CryptoAsset;
+  sourceAsset: keyof typeof CryptoAsset;
   /**
    * The fiat asset to be cashed out.
    */
-  destinationAsset: FiatAsset;
+  destinationAsset: keyof typeof FiatAsset;
   /**
    * A handler to notify you when a transaction needs to be sent.
    *

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -231,7 +231,7 @@ export type BaseConfiguration = Readonly<{
   /** The wallet address for the user. This address must be compatible with the selected `network` and `destinationAsset`. */
   walletAddress: string;
   /**
-   * A stringified number including decimals (if needed) representing the fiat amount to be used for the transfer.
+   * A stringified number including decimals (if needed) representing the amount to be used for the transfer.
    *
    * Examples: `"10",`"0.01"`, `"1.2"`, `"100.23"`, `"1250", `"1250.40"`.
    */

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -157,6 +157,11 @@ export const isCryptoAsset = (value: string): value is CryptoAsset => {
 export type AssetAmount = `${number}${"." | ""}${number | ""}`;
 
 /**
+ * @deprecated Legacy type for amount when only cash-in was supported
+ */
+export type USDAmount = AssetAmount;
+
+/**
  * Screen position to launch the Meso experience.
  */
 export enum Position {

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -118,15 +118,34 @@ export enum Network {
 }
 
 /**
- * Symbol representing a crypto/fiat currency.
+ * Symbol representing a cryptocurrency.
  */
-export enum Asset {
+export enum CryptoAsset {
   ETH = "ETH",
   SOL = "SOL",
   USDC = "USDC",
   MATIC = "MATIC",
+}
+
+/**
+ * Symbol representing a fiat currency.
+ */
+export enum FiatAsset {
   USD = "USD",
 }
+
+/**
+ * Symbol representing a crypto/fiat currency.
+ */
+export type Asset = CryptoAsset | FiatAsset;
+
+export const isFiatAsset = (value: string): value is FiatAsset => {
+  return Object.values(FiatAsset).includes(value as FiatAsset);
+};
+
+export const isCryptoAsset = (value: string): value is CryptoAsset => {
+  return Object.values(CryptoAsset).includes(value as CryptoAsset);
+};
 
 /**
  * A stringified number representing an amount of USD.
@@ -135,7 +154,7 @@ export enum Asset {
  *
  * Examples: `"10",`"0.01"`, `"1.2"`, `"100.23"`, `"1250"`, `"1250.40"`
  */
-export type USDAmount = `${number}${"." | ""}${number | ""}`;
+export type AssetAmount = `${number}${"." | ""}${number | ""}`;
 
 /**
  * Screen position to launch the Meso experience.
@@ -205,9 +224,9 @@ export type Layout = {
 };
 
 /**
- * Parameters to initialize the Meso experience.
+ * Shared parameters to initialize the Meso experience.
  */
-export type TransferConfiguration = Readonly<{
+export type BaseConfiguration = Readonly<{
   /**
    * The Meso environment to use. (`Environment.SANDBOX` | `Environment.PRODUCTION`).
    */
@@ -227,11 +246,7 @@ export type TransferConfiguration = Readonly<{
    *
    * Examples: `"10",`"0.01"`, `"1.2"`, `"100.23"`, `"1250", `"1250.40"`.
    */
-  sourceAmount: USDAmount;
-  /**
-   * The asset to be transferred.
-   */
-  destinationAsset: Asset;
+  sourceAmount: AssetAmount;
   /**
    * Configuration to customize how the Meso experience is launched and presented.
    */
@@ -249,8 +264,25 @@ export type TransferConfiguration = Readonly<{
    */
   onSignMessageRequest: (message: string) => Promise<SignedMessageResult>;
   /**
-   * A handler to notify you when a transaction needs to be sent. Require only
-   * when destinationAsset is a fiat `Asset`.
+   * A handler to notify you when an event has occurred.
+   */
+  onEvent: (event: MesoEvent) => void;
+}>;
+
+export type CashInConfiguration = BaseConfiguration & {
+  /**
+   * The asset to be transferred.
+   */
+  destinationAsset: CryptoAsset;
+};
+
+export type CashOutConfiguration = BaseConfiguration & {
+  /**
+   * The asset to be transferred.
+   */
+  destinationAsset: FiatAsset;
+  /**
+   * A handler to notify you when a transaction needs to be sent.
    *
    * @param amount - quantity of the cryptocurrency to send.
    * @param recipientAddress - wallet address of the transaction recipient.
@@ -258,18 +290,16 @@ export type TransferConfiguration = Readonly<{
    * @param decimals - number of decimal places used for the token.
    * @param interfaceDefinition - optional param defining the contract interface.
    */
-  onSendTransactionRequest?: (
+  onSendTransactionRequest: (
     amount: string,
     recipientAddress: string,
     tokenAddress: string,
     decimals: number,
     interfaceDefinition?: string,
   ) => Promise<void>;
-  /**
-   * A handler to notify you when an event has occurred.
-   */
-  onEvent: (event: MesoEvent) => void;
-}>;
+};
+
+export type TransferConfiguration = CashInConfiguration | CashOutConfiguration;
 
 /**
  * Used to determine the type of authentication the user will need to perform for a transfer.

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -117,9 +117,6 @@ export enum Network {
   OP_MAINNET = "eip155:10",
 }
 
-/**
- * Symbol representing a cryptocurrency.
- */
 export enum CryptoAsset {
   ETH = "ETH",
   SOL = "SOL",
@@ -127,25 +124,12 @@ export enum CryptoAsset {
   MATIC = "MATIC",
 }
 
-/**
- * Symbol representing a fiat currency.
- */
 export enum FiatAsset {
   USD = "USD",
 }
 
-/**
- * Symbol representing a crypto/fiat currency.
- */
 export type Asset = CryptoAsset | FiatAsset;
-
-export const isFiatAsset = (value: string): value is FiatAsset => {
-  return Object.values(FiatAsset).includes(value as FiatAsset);
-};
-
-export const isCryptoAsset = (value: string): value is CryptoAsset => {
-  return Object.values(CryptoAsset).includes(value as CryptoAsset);
-};
+export const Asset = { ...CryptoAsset, ...FiatAsset };
 
 /**
  * A stringified number representing an amount of USD.

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -449,7 +449,7 @@ export type RequestSendTransactionPayload = {
    * quantity to send for the transaction (e.g. `"10",`"0.01"`, `"1.2"`,
    * `"100.23"`, `"1250", `"1250.40"`).
    */
-  amount: string;
+  amount: AssetAmount;
   /*
    * Wallet address of the transaction recipient (i.e. the Meso Deposit Address for Cash-Ins).
    */

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -293,14 +293,12 @@ export type CashOutConfiguration = BaseConfiguration & {
    * @param recipientAddress - wallet address of the transaction recipient.
    * @param tokenAddress - contract address of the token being send.
    * @param decimals - number of decimal places used for the token.
-   * @param interfaceDefinition - optional param defining the contract interface.
    */
   onSendTransactionRequest: (
     amount: string,
     recipientAddress: string,
     tokenAddress: string,
     decimals: number,
-    interfaceDefinition?: string,
   ) => Promise<void>;
 };
 
@@ -464,10 +462,6 @@ export type RequestSendTransactionPayload = {
    * Number of decimal places used for the token (e.g. 6 for USDC on Ethereum).
    */
   decimals: number;
-  /*
-   * Optional param defining the contract interface (e.g. the ABI for ERC-20 token).
-   */
-  interfaceDefinition?: string;
 };
 
 /**

--- a/packages/meso-js/src/validateTransferConfiguration.ts
+++ b/packages/meso-js/src/validateTransferConfiguration.ts
@@ -1,13 +1,11 @@
 import {
   Asset,
   AuthenticationStrategy,
-  CryptoAsset,
   Environment,
   EventKind,
   FiatAsset,
   Network,
   TransferConfiguration,
-  isFiatAsset,
 } from "./types";
 import { validateLayout } from "./validateLayout";
 
@@ -65,18 +63,14 @@ export const validateTransferConfiguration = ({
       payload: { error: { message: `"walletAddress" must be provided.` } },
     });
     return false;
-  } else if (
-    !(destinationAsset in CryptoAsset) &&
-    !(destinationAsset in FiatAsset)
-  ) {
+  } else if (!(destinationAsset in Asset)) {
     onEvent({
       kind: EventKind.UNSUPPORTED_ASSET_ERROR,
       payload: {
         error: {
-          message: `"destinationAsset" must be a supported asset: ${[
-            ...Object.values(CryptoAsset),
-            ...Object.values(FiatAsset),
-          ]}.`,
+          message: `"destinationAsset" must be a supported asset: ${Object.values(
+            Asset,
+          )}.`,
         },
       },
     });
@@ -127,7 +121,7 @@ export const validateTransferConfiguration = ({
     });
     return false;
   } else if (
-    isFiatAsset(destinationAsset) &&
+    destinationAsset in FiatAsset &&
     (!("onSendTransactionRequest" in rest) ||
       typeof rest.onSendTransactionRequest !== "function")
   ) {

--- a/packages/meso-js/src/validators.ts
+++ b/packages/meso-js/src/validators.ts
@@ -64,6 +64,21 @@ export const validateMessage = (message: Message) => {
       }
 
       return true;
+    case MessageKind.REQUEST_SEND_TRANSACTION:
+      if (
+        !message.payload ||
+        !isString(message.payload.tokenAddress) ||
+        isEmptyString(message.payload.tokenAddress) ||
+        !isString(message.payload.recipientAddress) ||
+        isEmptyString(message.payload.recipientAddress) ||
+        typeof message.payload.decimals !== "number" ||
+        !isString(message.payload.amount) ||
+        isEmptyString(message.payload.amount)
+      ) {
+        return false;
+      }
+
+      return true;
     case MessageKind.CLOSE:
       if ("payload" in message) {
         return false;

--- a/packages/meso-js/test/bus.test.ts
+++ b/packages/meso-js/test/bus.test.ts
@@ -52,7 +52,7 @@ describe("setupBus", () => {
     }));
 
     expect(() =>
-      setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock),
+      setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock),
     ).toThrowErrorMatchingInlineSnapshot(
       '"Unable to initialize @meso-network/meso-js. Invalid iframe configuration."',
     );
@@ -62,7 +62,7 @@ describe("setupBus", () => {
     const onMock = vi.fn();
     createPostMessageBusMock.mockImplementationOnce(() => ({ on: onMock }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(
       MessageKind.REQUEST_SIGNED_MESSAGE,
       expect.any(Function),
@@ -105,7 +105,7 @@ describe("setupBus", () => {
       destroy: destroyMock,
     }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(MessageKind.CLOSE, expect.any(Function));
     const onCloseCallback = onMock.mock.calls.find(
       (invocationArgs) => invocationArgs[0] === MessageKind.CLOSE,
@@ -133,7 +133,7 @@ describe("setupBus", () => {
       destroy: destroyMock,
     }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(
       MessageKind.TRANSFER_UPDATE,
       expect.any(Function),
@@ -170,7 +170,7 @@ describe("setupBus", () => {
       destroy: destroyMock,
     }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(
       MessageKind.TRANSFER_UPDATE,
       expect.any(Function),
@@ -204,7 +204,7 @@ describe("setupBus", () => {
     const onMock = vi.fn();
     createPostMessageBusMock.mockImplementationOnce(() => ({ on: onMock }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(MessageKind.ERROR, expect.any(Function));
     const onErrorCallback = onMock.mock.calls.find(
       (invocationArgs) => invocationArgs[0] === MessageKind.ERROR,
@@ -228,7 +228,7 @@ describe("setupBus", () => {
     const onMock = vi.fn();
     createPostMessageBusMock.mockImplementationOnce(() => ({ on: onMock }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(
       MessageKind.CONFIGURATION_ERROR,
       expect.any(Function),
@@ -258,7 +258,7 @@ describe("setupBus", () => {
     const onMock = vi.fn();
     createPostMessageBusMock.mockImplementationOnce(() => ({ on: onMock }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(
       MessageKind.UNSUPPORTED_NETWORK_ERROR,
       expect.any(Function),
@@ -289,7 +289,7 @@ describe("setupBus", () => {
     const onMock = vi.fn();
     createPostMessageBusMock.mockImplementationOnce(() => ({ on: onMock }));
 
-    setupBus(apiHost, frame, onSignMessageRequestMock, onEventMock);
+    setupBus(apiHost, frame, onEventMock, onSignMessageRequestMock);
     expect(onMock).toBeCalledWith(
       MessageKind.UNSUPPORTED_ASSET_ERROR,
       expect.any(Function),

--- a/packages/meso-js/test/factories/index.ts
+++ b/packages/meso-js/test/factories/index.ts
@@ -18,6 +18,7 @@ export const serializedTransferIframeParamsFactory: {
       network: Network.ETHEREUM_MAINNET,
       walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       sourceAmount: "100",
+      sourceAsset: Asset.USD,
       destinationAsset: Asset.ETH,
       layoutPosition: Position.TOP_RIGHT,
       layoutOffset: "0",

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -25,6 +25,7 @@ describe("setupFrame", () => {
           "network": "eip155:1",
           "partnerId": "partnerId",
           "sourceAmount": "100",
+          "sourceAsset": "USD",
           "version": "1.0.0",
           "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         }
@@ -71,7 +72,7 @@ describe("setupFrame", () => {
     expect(setupFrameRes.element.attributes).toMatchInlineSnapshot(`
       NamedNodeMap {
         "allowtransparency": "true",
-        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification&mode=embedded",
+        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&sourceAsset=USD&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification&mode=embedded",
         "style": "position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 9999; box-sizing: border-box; background-color: transparent; color-scheme: auto;",
       }
     `);

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -52,7 +52,7 @@ describe("transfer", () => {
     expect(setupBusMock).not.toHaveBeenCalled();
   });
 
-  test("valid configuration sets up frame, bus, and returns destroy method to clean up both", () => {
+  test("valid cash-in configuration sets up frame, bus, and returns destroy method to clean up both", () => {
     validateTransferConfigurationMock.mockImplementationOnce(() => true);
     const frameRemoveMock = vi.fn();
     setupFrameMock.mockImplementationOnce(() => ({ remove: frameRemoveMock }));
@@ -89,6 +89,59 @@ describe("transfer", () => {
         {
           "remove": [MockFunction spy],
         },
+        [MockFunction spy],
+        [MockFunction spy],
+        undefined,
+      ]
+    `);
+
+    destroy();
+    expect(frameRemoveMock).toHaveBeenCalledOnce();
+    expect(busDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  test("valid cash-out configuration sets up frame, bus, and returns destroy method to clean up both", () => {
+    validateTransferConfigurationMock.mockImplementationOnce(() => true);
+    const frameRemoveMock = vi.fn();
+    setupFrameMock.mockImplementationOnce(() => ({ remove: frameRemoveMock }));
+    const busDestroyMock = vi.fn();
+    setupBusMock.mockImplementationOnce(() => ({ destroy: busDestroyMock }));
+
+    const { destroy } = transfer({
+      ...configuration,
+      destinationAsset: Asset.USD,
+      onSendTransactionRequest: vi.fn(),
+    });
+    expect(setupFrameMock).toHaveBeenCalledOnce();
+    expect(setupFrameMock.mock.lastCall[0]).toMatchInlineSnapshot(
+      '"https://api.sandbox.meso.network"',
+    );
+    expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
+      { version: expect.any(String) },
+      `
+      {
+        "authenticationStrategy": "wallet_verification",
+        "destinationAsset": "USD",
+        "layoutOffset": "0",
+        "layoutPosition": "top-right",
+        "mode": "embedded",
+        "network": "eip155:1",
+        "partnerId": "partnerId",
+        "sourceAmount": "100",
+        "version": Any<String>,
+        "walletAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      }
+    `,
+    );
+    expect(setupFrameMock.mock.lastCall[1].version).toEqual(version);
+    expect(setupBusMock).toHaveBeenCalledOnce();
+    expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        "https://api.sandbox.meso.network",
+        {
+          "remove": [MockFunction spy],
+        },
+        [MockFunction spy],
         [MockFunction spy],
         [MockFunction spy],
       ]

--- a/packages/meso-js/test/validateTransferConfiguration.test.ts
+++ b/packages/meso-js/test/validateTransferConfiguration.test.ts
@@ -142,32 +142,6 @@ describe("validateTransferConfiguration", () => {
     `);
   });
 
-  test("non-Asset emits", () => {
-    expect(
-      validateTransferConfiguration({
-        onEvent,
-        sourceAmount: "1",
-        network: Network.ETHEREUM_MAINNET,
-        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        // @ts-expect-error: Bypass type system to simulate runtime behavior
-        destinationAsset: "C2O",
-      }),
-    ).toBe(false);
-    expect(onEvent).toHaveBeenCalledOnce();
-    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "UNSUPPORTED_ASSET_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"destinationAsset\\" must be a supported asset: ETH,SOL,USDC,MATIC,USD.",
-            },
-          },
-        },
-      ]
-    `);
-  });
-
   test("non-Environment emits", () => {
     expect(
       validateTransferConfiguration({
@@ -366,82 +340,6 @@ describe("validateTransferConfiguration", () => {
         },
       ]
     `);
-  });
-
-  describe("onSendTransaction", () => {
-    test("undefined is valid when destination is Crypto", () => {
-      expect(
-        validateTransferConfiguration({
-          onEvent,
-          sourceAmount: "1",
-          network: Network.ETHEREUM_MAINNET,
-          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-          destinationAsset: Asset.USDC,
-          environment: Environment.SANDBOX,
-          partnerId: "meso-js-test",
-          onSignMessageRequest: vi.fn(),
-        }),
-      ).toBe(true);
-    });
-
-    test("non-function onSendTransaction emits when destination asset is Fiat", () => {
-      expect(
-        validateTransferConfiguration({
-          onEvent,
-          sourceAmount: "1",
-          network: Network.ETHEREUM_MAINNET,
-          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-          destinationAsset: Asset.USD,
-          environment: Environment.SANDBOX,
-          partnerId: "meso-js-test",
-          onSignMessageRequest: vi.fn(),
-          // @ts-expect-error: Bypass type system to simulate runtime behavior
-          onSendTransactionRequest: "sentTransaction",
-        }),
-      ).toBe(false);
-      expect(onEvent).toHaveBeenCalledOnce();
-      expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "CONFIGURATION_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"onSendTransactionRequest\\" must be a valid function.",
-            },
-          },
-        },
-      ]
-    `);
-    });
-
-    test("missing onSendTransaction emits when destination asset is Fiat", () => {
-      expect(
-        // @ts-expect-error: Bypass type system to simulate runtime behavior
-        validateTransferConfiguration({
-          onEvent,
-          sourceAmount: "1",
-          network: Network.ETHEREUM_MAINNET,
-          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-          destinationAsset: Asset.USD,
-          environment: Environment.SANDBOX,
-          partnerId: "meso-js-test",
-          onSignMessageRequest: vi.fn(),
-        }),
-      ).toBe(false);
-      expect(onEvent).toHaveBeenCalledOnce();
-      expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "CONFIGURATION_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"onSendTransactionRequest\\" must be a valid function.",
-            },
-          },
-        },
-      ]
-    `);
-    });
   });
 
   describe("layout", () => {
@@ -690,105 +588,276 @@ describe("validateTransferConfiguration", () => {
         });
       });
     });
+
+    describe("valid configuration", () => {
+      test("returns true (no layout)", () => {
+        const valid = validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.ETH,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          onSignMessageRequest: vi.fn(),
+        });
+        expect(onEvent).not.toHaveBeenCalled();
+        expect(valid).toBe(true);
+      });
+
+      test("returns true (no position)", () => {
+        const valid = validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.ETH,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          layout: { offset: "0" },
+          onSignMessageRequest: vi.fn(),
+        });
+        expect(onEvent).not.toHaveBeenCalled();
+        expect(valid).toBe(true);
+      });
+
+      test("returns true (no offset)", () => {
+        const valid = validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.ETH,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          layout: { position: Position.TOP_RIGHT, offset: "0" },
+          onSignMessageRequest: vi.fn(),
+        });
+        expect(onEvent).not.toHaveBeenCalled();
+        expect(valid).toBe(true);
+      });
+
+      test("returns true (single value offset)", () => {
+        const valid = validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.ETH,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          layout: { position: Position.TOP_RIGHT, offset: "0" },
+          onSignMessageRequest: vi.fn(),
+        });
+        expect(onEvent).not.toHaveBeenCalled();
+        expect(valid).toBe(true);
+      });
+
+      test("returns true (x-only offset)", () => {
+        const valid = validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.ETH,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          layout: {
+            position: Position.TOP_RIGHT,
+            offset: { horizontal: "10" },
+          },
+          onSignMessageRequest: vi.fn(),
+        });
+        expect(onEvent).not.toHaveBeenCalled();
+        expect(valid).toBe(true);
+      });
+
+      test("returns true (x/y offset)", () => {
+        const valid = validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.ETH,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          layout: {
+            position: Position.TOP_RIGHT,
+            offset: { horizontal: "10", vertical: "22" },
+          },
+          onSignMessageRequest: vi.fn(),
+        });
+        expect(onEvent).not.toHaveBeenCalled();
+        expect(valid).toBe(true);
+      });
+    });
   });
 
-  describe("valid configuration", () => {
-    test("returns true (no layout)", () => {
-      const valid = validateTransferConfiguration({
+  test("non-Asset destinationAsset emits", () => {
+    expect(
+      validateTransferConfiguration({
         onEvent,
         sourceAmount: "1",
         network: Network.ETHEREUM_MAINNET,
         walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        destinationAsset: Asset.ETH,
+        // @ts-expect-error: Bypassing types for testing
+        destinationAsset: "$",
         environment: Environment.SANDBOX,
         partnerId: "meso-js-test",
         onSignMessageRequest: vi.fn(),
-      });
-      expect(onEvent).not.toHaveBeenCalled();
-      expect(valid).toBe(true);
-    });
-
-    test("returns true (no position)", () => {
-      const valid = validateTransferConfiguration({
-        onEvent,
-        sourceAmount: "1",
-        network: Network.ETHEREUM_MAINNET,
-        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        destinationAsset: Asset.ETH,
-        environment: Environment.SANDBOX,
-        partnerId: "meso-js-test",
-        layout: { offset: "0" },
-        onSignMessageRequest: vi.fn(),
-      });
-      expect(onEvent).not.toHaveBeenCalled();
-      expect(valid).toBe(true);
-    });
-
-    test("returns true (no offset)", () => {
-      const valid = validateTransferConfiguration({
-        onEvent,
-        sourceAmount: "1",
-        network: Network.ETHEREUM_MAINNET,
-        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        destinationAsset: Asset.ETH,
-        environment: Environment.SANDBOX,
-        partnerId: "meso-js-test",
-        layout: { position: Position.TOP_RIGHT, offset: "0" },
-        onSignMessageRequest: vi.fn(),
-      });
-      expect(onEvent).not.toHaveBeenCalled();
-      expect(valid).toBe(true);
-    });
-
-    test("returns true (single value offset)", () => {
-      const valid = validateTransferConfiguration({
-        onEvent,
-        sourceAmount: "1",
-        network: Network.ETHEREUM_MAINNET,
-        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        destinationAsset: Asset.ETH,
-        environment: Environment.SANDBOX,
-        partnerId: "meso-js-test",
-        layout: { position: Position.TOP_RIGHT, offset: "0" },
-        onSignMessageRequest: vi.fn(),
-      });
-      expect(onEvent).not.toHaveBeenCalled();
-      expect(valid).toBe(true);
-    });
-
-    test("returns true (x-only offset)", () => {
-      const valid = validateTransferConfiguration({
-        onEvent,
-        sourceAmount: "1",
-        network: Network.ETHEREUM_MAINNET,
-        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        destinationAsset: Asset.ETH,
-        environment: Environment.SANDBOX,
-        partnerId: "meso-js-test",
-        layout: { position: Position.TOP_RIGHT, offset: { horizontal: "10" } },
-        onSignMessageRequest: vi.fn(),
-      });
-      expect(onEvent).not.toHaveBeenCalled();
-      expect(valid).toBe(true);
-    });
-
-    test("returns true (x/y offset)", () => {
-      const valid = validateTransferConfiguration({
-        onEvent,
-        sourceAmount: "1",
-        network: Network.ETHEREUM_MAINNET,
-        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        destinationAsset: Asset.ETH,
-        environment: Environment.SANDBOX,
-        partnerId: "meso-js-test",
-        layout: {
-          position: Position.TOP_RIGHT,
-          offset: { horizontal: "10", vertical: "22" },
+      }),
+    ).toBe(false);
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "UNSUPPORTED_ASSET_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"destinationAsset\\" must be a supported Asset: ETH,SOL,USDC,MATIC,USD.",
+            },
+          },
         },
+      ]
+    `);
+  });
+
+  test("non-CryptoAsset sourceAsset when destinationAsset is FiatAsset emits", () => {
+    expect(
+      // @ts-expect-error: Bypassing types for testing
+      validateTransferConfiguration({
+        onEvent,
+        sourceAmount: "1",
+        network: Network.ETHEREUM_MAINNET,
+        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        sourceAsset: Asset.USD,
+        destinationAsset: Asset.USD,
+        environment: Environment.SANDBOX,
+        partnerId: "meso-js-test",
         onSignMessageRequest: vi.fn(),
-      });
-      expect(onEvent).not.toHaveBeenCalled();
-      expect(valid).toBe(true);
+        onSendTransactionRequest: vi.fn(),
+      }),
+    ).toBe(false);
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "UNSUPPORTED_ASSET_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"sourceAsset\\" must be a supported CryptoAsset for Cash-out: ETH,SOL,USDC,MATIC.",
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  test("non-FiatAsset sourceAsset when destinationAsset is CryptoAsset emits", () => {
+    expect(
+      // @ts-expect-error: Bypassing types for testing
+      validateTransferConfiguration({
+        onEvent,
+        sourceAmount: "1",
+        network: Network.ETHEREUM_MAINNET,
+        walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        sourceAsset: Asset.ETH,
+        destinationAsset: Asset.ETH,
+        environment: Environment.SANDBOX,
+        partnerId: "meso-js-test",
+        onSignMessageRequest: vi.fn(),
+      }),
+    ).toBe(false);
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "UNSUPPORTED_ASSET_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"sourceAsset\\" must be a supported FiatAsset for Cash-in: USD.",
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  describe("onSendTransaction", () => {
+    test("undefined is valid when destinationAsset is CryptoAsset", () => {
+      expect(
+        validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.USDC,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          onSignMessageRequest: vi.fn(),
+        }),
+      ).toBe(true);
+    });
+
+    test("non-function onSendTransaction emits when destinationAsset is FiatAsset", () => {
+      expect(
+        validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          sourceAsset: Asset.ETH,
+          destinationAsset: Asset.USD,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          onSignMessageRequest: vi.fn(),
+          // @ts-expect-error: Bypass type system to simulate runtime behavior
+          onSendTransactionRequest: "sentTransaction",
+        }),
+      ).toBe(false);
+      expect(onEvent).toHaveBeenCalledOnce();
+      expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "CONFIGURATION_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"onSendTransactionRequest\\" must be a valid function.",
+            },
+          },
+        },
+      ]
+    `);
+    });
+
+    test("missing onSendTransaction emits when destinationAsset is FiatAsset", () => {
+      expect(
+        // @ts-expect-error: Bypass type system to simulate runtime behavior
+        validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          sourceAsset: Asset.ETH,
+          destinationAsset: Asset.USD,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          onSignMessageRequest: vi.fn(),
+        }),
+      ).toBe(false);
+      expect(onEvent).toHaveBeenCalledOnce();
+      expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "CONFIGURATION_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"onSendTransactionRequest\\" must be a valid function.",
+            },
+          },
+        },
+      ]
+    `);
     });
   });
 });

--- a/packages/meso-js/test/validateTransferConfiguration.test.ts
+++ b/packages/meso-js/test/validateTransferConfiguration.test.ts
@@ -160,7 +160,7 @@ describe("validateTransferConfiguration", () => {
           "kind": "UNSUPPORTED_ASSET_ERROR",
           "payload": {
             "error": {
-              "message": "\\"destinationAsset\\" must be a supported asset: ETH,SOL,USDC,MATIC.",
+              "message": "\\"destinationAsset\\" must be a supported asset: ETH,SOL,USDC,MATIC,USD.",
             },
           },
         },
@@ -368,6 +368,82 @@ describe("validateTransferConfiguration", () => {
     `);
   });
 
+  describe("onSendTransaction", () => {
+    test("undefined is valid when destination is Crypto", () => {
+      expect(
+        validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.USDC,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          onSignMessageRequest: vi.fn(),
+        }),
+      ).toBe(true);
+    });
+
+    test("non-function onSendTransaction emits when destination asset is Fiat", () => {
+      expect(
+        validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.USD,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          onSignMessageRequest: vi.fn(),
+          // @ts-expect-error: Bypass type system to simulate runtime behavior
+          onSendTransactionRequest: "sentTransaction",
+        }),
+      ).toBe(false);
+      expect(onEvent).toHaveBeenCalledOnce();
+      expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "CONFIGURATION_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"onSendTransactionRequest\\" must be a valid function.",
+            },
+          },
+        },
+      ]
+    `);
+    });
+
+    test("missing onSendTransaction emits when destination asset is Fiat", () => {
+      expect(
+        // @ts-expect-error: Bypass type system to simulate runtime behavior
+        validateTransferConfiguration({
+          onEvent,
+          sourceAmount: "1",
+          network: Network.ETHEREUM_MAINNET,
+          walletAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          destinationAsset: Asset.USD,
+          environment: Environment.SANDBOX,
+          partnerId: "meso-js-test",
+          onSignMessageRequest: vi.fn(),
+        }),
+      ).toBe(false);
+      expect(onEvent).toHaveBeenCalledOnce();
+      expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "CONFIGURATION_ERROR",
+          "payload": {
+            "error": {
+              "message": "\\"onSendTransactionRequest\\" must be a valid function.",
+            },
+          },
+        },
+      ]
+    `);
+    });
+  });
+
   describe("layout", () => {
     test("invalid `position` emits an error", () => {
       expect(
@@ -444,7 +520,7 @@ describe("validateTransferConfiguration", () => {
             validateTransferConfiguration({
               ...configuration,
               layout: { position: Position.TOP_RIGHT, offset: "-10" },
-            }),
+            } as TransferConfiguration),
           ).toBe(false);
           expect(onEvent).toHaveBeenCalledOnce();
           expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
@@ -546,7 +622,7 @@ describe("validateTransferConfiguration", () => {
                 position: Position.TOP_RIGHT,
                 offset: { horizontal: "-10" },
               },
-            }),
+            } as TransferConfiguration),
           ).toBe(false);
           expect(onEvent).toHaveBeenCalledOnce();
           expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
@@ -571,7 +647,7 @@ describe("validateTransferConfiguration", () => {
                 position: Position.TOP_RIGHT,
                 offset: { vertical: "-10" },
               },
-            }),
+            } as TransferConfiguration),
           ).toBe(false);
           expect(onEvent).toHaveBeenCalledOnce();
           expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
@@ -596,7 +672,7 @@ describe("validateTransferConfiguration", () => {
                 position: Position.TOP_RIGHT,
                 offset: { horizontal: "-1", vertical: "-10" },
               },
-            }),
+            } as TransferConfiguration),
           ).toBe(false);
           expect(onEvent).toHaveBeenCalledOnce();
           expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`

--- a/packages/meso-js/test/validateTransferConfiguration.test.ts
+++ b/packages/meso-js/test/validateTransferConfiguration.test.ts
@@ -23,7 +23,7 @@ describe("validateTransferConfiguration", () => {
     );
   });
 
-  test("sourceAmount not matching USDAmount template literal emits", () => {
+  test("sourceAmount not matching AssetAmount template literal emits", () => {
     // @ts-expect-error: Bypass type system to simulate runtime behavior
     expect(validateTransferConfiguration({ onEvent, sourceAmount: "1." })).toBe(
       false,

--- a/packages/meso-js/test/validators.test.ts
+++ b/packages/meso-js/test/validators.test.ts
@@ -111,6 +111,92 @@ describe("validators", () => {
       });
     });
 
+    describe("REQUEST_SEND_TRANSACTION", () => {
+      describe("success", () => {
+        test("returns valid payload", () => {
+          expect(
+            validateMessage({
+              kind: MessageKind.REQUEST_SEND_TRANSACTION,
+              payload: {
+                tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                recipientAddress: "0xDD9Dc1c1Df9bf81044Faa745410f37dfF321BC97",
+                decimals: 6,
+                amount: "100.00",
+              },
+            }),
+          ).toBe(true);
+        });
+      });
+
+      describe("failure", () => {
+        test.each([
+          ["missing payload", { kind: MessageKind.REQUEST_SEND_TRANSACTION }],
+          [
+            "missing kind",
+            {
+              payload: {
+                tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                recipientAddress: "0xDD9Dc1c1Df9bf81044Faa745410f37dfF321BC97",
+                decimals: 6,
+                amount: "100.00",
+              },
+            },
+          ],
+          [
+            "bad tokenAddress",
+            {
+              kind: MessageKind.REQUEST_SEND_TRANSACTION,
+              payload: {
+                tokenAddress: "",
+                recipientAddress: "0xDD9Dc1c1Df9bf81044Faa745410f37dfF321BC97",
+                decimals: 6,
+                amount: "100.00",
+              },
+            },
+          ],
+          [
+            "bad recipientAddress",
+            {
+              kind: MessageKind.REQUEST_SEND_TRANSACTION,
+              payload: {
+                tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                recipientAddress: "",
+                decimals: 6,
+                amount: "100.00",
+              },
+            },
+          ],
+          [
+            "bad decimals",
+            {
+              kind: MessageKind.REQUEST_SEND_TRANSACTION,
+              payload: {
+                tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                recipientAddress: "0xDD9Dc1c1Df9bf81044Faa745410f37dfF321BC97",
+                decimals: "6",
+                amount: "100.00",
+              },
+            },
+          ],
+          [
+            "bad amount",
+            {
+              kind: MessageKind.REQUEST_SEND_TRANSACTION,
+              payload: {
+                tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                recipientAddress: "0xDD9Dc1c1Df9bf81044Faa745410f37dfF321BC97",
+                decimals: 6,
+                amount: 100,
+              },
+            },
+          ],
+        ])("%s", (_, message) => {
+          // @ts-expect-error: Bypass type system to simulate runtime behavior
+          expect(validateMessage(message)).toBe(false);
+        });
+      });
+    });
+
     describe("CLOSE", () => {
       describe("success", () => {
         test("is valid", () => {


### PR DESCRIPTION
Support cash-outs by expanding the `transfer` API, which now supports a `destinationAsset` value of `Asset.USD` and an optional `onSendTransactionRequest` callback.

