### PR TITLE
fix(@meso-network/meso-js): 🐛 Ensure READY event is added to message validation

### DIFF
--- a/.changeset/slimy-parents-kneel.md
+++ b/.changeset/slimy-parents-kneel.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+🐛 This release fixes a bug introduced in [v0.0.81](https://github.com/meso-network/meso-js/releases/tag/%40meso-network%2Fmeso-js%400.0.81) where the `READY` event would not be surfaced. We now ensure the `READY` event is passed through message validation.

--- a/packages/meso-js/src/validators.ts
+++ b/packages/meso-js/src/validators.ts
@@ -65,6 +65,7 @@ export const validateMessage = (message: Message) => {
 
       return true;
     case MessageKind.CLOSE:
+    case MessageKind.READY:
       if ("payload" in message) {
         return false;
       }

--- a/packages/meso-js/test/validators.test.ts
+++ b/packages/meso-js/test/validators.test.ts
@@ -129,6 +129,24 @@ describe("validators", () => {
       });
     });
 
+    describe("READY", () => {
+      describe("success", () => {
+        test("is valid", () => {
+          expect(validateMessage({ kind: MessageKind.READY })).toBe(true);
+        });
+      });
+
+      describe("failure", () => {
+        test.each([
+          ["contains payload", { kind: MessageKind.READY, payload: {} }],
+          ["missing kind", {}],
+        ])("%s", (_, message) => {
+          // @ts-expect-error: Bypass type system to simulate runtime behavior
+          expect(validateMessage(message)).toBe(false);
+        });
+      });
+    });
+
     describe("TRANSFER_UPDATE", () => {
       describe("success", () => {
         test("is valid w/o networkTransactionId", () => {


### PR DESCRIPTION
This fixes a bug introduced in #49.