### PR TITLE
chore(@meso-network): :arrow_down: Bump actions/checkout and actions/setup-node to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: checkout code repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 


### PR DESCRIPTION
This will address the warning that we are out of date on each CI run

![Screenshot 2024-04-22 at 2 37 21 PM](https://github.com/meso-network/meso-js/assets/1217116/104581cd-fcc4-4559-bf6f-734839c9d28b)
