### PR TITLE
fix(@meso-network/meso-js): :goal_net: guard against missing frame when unmounting sibling iframes in the inline integration

### DIFF
--- a/.changeset/wild-ducks-try.md
+++ b/.changeset/wild-ducks-try.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+🥅 Fixes a bug in the inline integration where if a developer called `destroy()` and the reference to the modal onboarding frame was lost, our logic would throw an undue exception. We now guard against missing frames when amounting.

--- a/packages/meso-js/src/inlineTransfer.ts
+++ b/packages/meso-js/src/inlineTransfer.ts
@@ -91,7 +91,8 @@ export const inlineTransfer = (
       frameStore.modalOnboardingIframe.parentNode?.removeChild(
         frameStore.modalOnboardingIframe,
       );
-      frameStore.modalOnboardingIframe = undefined;
+
+      delete frameStore.modalOnboardingIframe;
 
       reply({
         kind: MessageKind.RESUME_INLINE_FRAME,
@@ -105,7 +106,9 @@ export const inlineTransfer = (
       frame.remove();
       // Remove each frame in the story
       Object.values(frameStore).forEach((frame) => {
-        frame.parentNode?.removeChild(frame);
+        if (typeof frame === "object" && "parentNode" in frame) {
+          frame.parentNode?.removeChild(frame);
+        }
       });
 
       bus.destroy();


### PR DESCRIPTION
This prevents a bug where if a developer called `destroy()` and the reference to the modal onboarding frame was lost, our logic would throw an undue exception.