### PR TITLE
feat(@meso-network/meso-js): add ONBOARDING_TERMINATED type to inline frame actions

### DIFF
--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -521,6 +521,8 @@ export type RequestSendTransactionPayload = {
 export enum ResumeInlineFrameAction {
   ONBOARDING_COMPLETE = "ONBOARDING_COMPLETE",
   ONBOARDING_CANCELED = "ONBOARDING_CANCELED",
+  /** Onboarding has been terminated due to a user hitting Manual Review */
+  ONBOARDING_TERMINATED = "ONBOARDING_TERMINATED",
   /** The user is attempting to login instead of signing up. */
   LOGIN_FROM_ONBOARDING = "LOGIN_FROM_ONBOARDING",
 }


### PR DESCRIPTION
This allows us to have another signal when dismissing modal onboarding in the inline integration.