### PR TITLE
feat(@meso-network/meso-js): add ONBOARDING_TERMINATED type to inline frame actions

### DIFF
--- a/.changeset/new-pens-raise.md
+++ b/.changeset/new-pens-raise.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Adds `ONBOARDING_TERMINATED` to frame request events. This allows us to have another signal when dismissing modal onboarding in the inline integration.

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -520,7 +520,8 @@ export type RequestSendTransactionPayload = {
 
 export enum ResumeInlineFrameAction {
   ONBOARDING_COMPLETE = "ONBOARDING_COMPLETE",
-  ONBOARDING_CANCELED = "ONBOARDING_CANCELED",
+  ONBOARDING_CANCELED = "ONBOARDING_CANCELED" /** Onboarding has been terminated due to a user hitting Manual Review */,
+  ONBOARDING_TERMINATED = "ONBOARDING_TERMINATED",
   /** The user is attempting to login instead of signing up. */
   LOGIN_FROM_ONBOARDING = "LOGIN_FROM_ONBOARDING",
 }


### PR DESCRIPTION
This allows us to have another signal when dismissing modal onboarding in the inline integration
