### PR TITLE
feat(@meso-network/meso-js): ✨ Add TRANSFER_INCOMPLETE to onEvent callback

### DIFF
--- a/.changeset/nasty-pets-shave.md
+++ b/.changeset/nasty-pets-shave.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Adds the `TRANSFER_INCOMPLETE` event to the [`onEvent`](https://developers.meso.network/javascript-sdk/reference#on-event) callback.
+
+This event is dispatched only for the `inlineTransfer` integration and signals the user was unable to complete onboarding due to KYC failures/restrictions. It is not the same as the user canceling the flow.

--- a/packages/meso-js/src/inlineTransfer.ts
+++ b/packages/meso-js/src/inlineTransfer.ts
@@ -4,9 +4,11 @@ import { renderModalOnboardingFrame, setupFrame } from "./frame";
 import {
   Asset,
   AuthenticationStrategy,
+  EventKind,
   InlineCashOutConfiguration,
   InlineTransferConfiguration,
   MessageKind,
+  ResumeInlineFrameAction,
   TransferExperienceMode,
   TransferInstance,
 } from "./types";
@@ -107,6 +109,16 @@ export const inlineTransfer = (
       reply({
         kind: MessageKind.RESUME_INLINE_FRAME,
         payload: message.payload,
+      });
+    }
+
+    if (
+      message.payload.action === ResumeInlineFrameAction.ONBOARDING_TERMINATED
+    ) {
+      // Call developer callback
+      onEvent({
+        kind: EventKind.TRANSFER_INCOMPLETE,
+        payload: null,
       });
     }
   });

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -80,6 +80,14 @@ export enum EventKind {
   TRANSFER_APPROVED = "TRANSFER_APPROVED",
   /** A Meso transfer has completed */
   TRANSFER_COMPLETE = "TRANSFER_COMPLETE",
+  /**
+   * The user's transfer is incomplete. Upon seeing this event, the integration can be unmounted.
+   *
+   * This event is emitted if the user was unable to complete onboarding due to KYC failures/restrictions. It is not the same as the user canceling the flow.
+   *
+   * **Note:** This event is only fired in the `inline` integration.
+   */
+  TRANSFER_INCOMPLETE = "TRANSFER_INCOMPLETE",
   /** The iframe/window is ready and can be interacted with. */
   READY = "READY",
 }
@@ -100,8 +108,10 @@ export type MesoEvent =
       kind: EventKind.UNSUPPORTED_ASSET_ERROR;
       payload: UnsupportedAssetErrorPayload;
     }
-  | { kind: EventKind.CLOSE; payload: null }
-  | { kind: EventKind.READY; payload: null };
+  | {
+      kind: EventKind.CLOSE | EventKind.READY | EventKind.TRANSFER_INCOMPLETE;
+      payload: null;
+    };
 
 /**
  * The expected result from requesting the user to sign a message with their wallet.


### PR DESCRIPTION
This adds the `TRANSFER_INCOMPLETE` event to the [`onEvent`](https://developers.meso.network/javascript-sdk/reference#on-event) callback.

This event is dispatched only for the `inlineTransfer` integration and signals the user was unable to complete onboarding due to KYC failures/restrictions. It is not the same as the user canceling the flow.