### PR TITLE
feat(@meso-network/meso-js): Allow passing query string to modal onboarding frame for the inline integration

### DIFF
--- a/.changeset/cuddly-bats-watch.md
+++ b/.changeset/cuddly-bats-watch.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Allow passing query params to modal onboarding frame for `inlineTransfer` integrations.

--- a/packages/meso-js/src/frame.ts
+++ b/packages/meso-js/src/frame.ts
@@ -63,15 +63,17 @@ const renderIframe = (src: string, containerElement: Element | null) => {
 export const renderModalOnboardingFrame = ({
   apiHost,
   pathname,
+  search,
 }: {
   apiHost: string;
   pathname: string;
+  search?: string;
 }) => {
   const route = pathname.startsWith(MODAL_ONBOARDING_PATH_PREFIX)
     ? pathname
     : `${MODAL_ONBOARDING_PATH_PREFIX}/${pathname}`;
 
-  const src = `${apiHost}${route.replaceAll("//", "/")}`;
+  const src = `${apiHost}${route.replaceAll("//", "/")}${search}`;
 
   const iframe = document.createElement("iframe");
   iframe.src = src;

--- a/packages/meso-js/src/frame.ts
+++ b/packages/meso-js/src/frame.ts
@@ -67,13 +67,13 @@ export const renderModalOnboardingFrame = ({
 }: {
   apiHost: string;
   pathname: string;
-  search?: string;
+  search?: `?${string}`;
 }) => {
   const route = pathname.startsWith(MODAL_ONBOARDING_PATH_PREFIX)
     ? pathname
     : `${MODAL_ONBOARDING_PATH_PREFIX}/${pathname}`;
 
-  const src = `${apiHost}${route.replaceAll("//", "/")}${search}`;
+  const src = `${apiHost}${route.replaceAll("//", "/")}${search ?? ""}`.trim();
 
   const iframe = document.createElement("iframe");
   iframe.src = src;

--- a/packages/meso-js/src/inlineTransfer.ts
+++ b/packages/meso-js/src/inlineTransfer.ts
@@ -91,6 +91,7 @@ export const inlineTransfer = (
     const modalOnboardingIframe = renderModalOnboardingFrame({
       apiHost,
       pathname: message.payload.initialPathname,
+      search: message.payload.search,
     });
 
     frameStore.modalOnboardingIframe = modalOnboardingIframe;

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -570,6 +570,8 @@ export type Message =
          * The qualified pathname (including leading `/`) in Onboarding that the user will land on once the modal is opened.
          */
         initialPathname: string;
+        // TODO:
+        search: string;
       };
     }
   | {

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -544,6 +544,9 @@ export type ResumeInlineFramePayload = {
   action: ResumeInlineFrameAction;
 };
 
+/** A valid query param string with the leading `?` */
+export type QueryString = `?${string}`;
+
 /**
  * Structured `window.postMessage` messages between the Meso experience to parent window
  */
@@ -572,7 +575,7 @@ export type Message =
         initialPathname: string;
 
         /** If provided, a valid query param string with the leading `?`*/
-        search?: `?${string}`;
+        search?: QueryString;
       };
     }
   | {

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -570,8 +570,9 @@ export type Message =
          * The qualified pathname (including leading `/`) in Onboarding that the user will land on once the modal is opened.
          */
         initialPathname: string;
-        // TODO:
-        search: string;
+
+        /** If provided, a valid query param string with the leading `?`*/
+        search?: `?${string}`;
       };
     }
   | {

--- a/packages/meso-js/src/validators.ts
+++ b/packages/meso-js/src/validators.ts
@@ -132,8 +132,17 @@ export const validateMessage = (message: Message) => {
         !isString(message.payload.initialPathname) ||
         isEmptyString(message.payload.initialPathname)
       ) {
-        // TODO: validate search string
         return false;
+      }
+
+      // Safely allow `search` to be omitted for backwards compatibility. We only validate if it's present
+      if ("search" in message.payload) {
+        if (
+          !isString(message.payload.search) ||
+          isEmptyString(message.payload.search)
+        ) {
+          return false;
+        }
       }
 
       return true;

--- a/packages/meso-js/src/validators.ts
+++ b/packages/meso-js/src/validators.ts
@@ -132,6 +132,7 @@ export const validateMessage = (message: Message) => {
         !isString(message.payload.initialPathname) ||
         isEmptyString(message.payload.initialPathname)
       ) {
+        // TODO: validate search string
         return false;
       }
 

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -124,6 +124,22 @@ describe("frame", () => {
         `);
     });
 
+    test("renders iframe element with provided pathname and query string", () => {
+      const frame = renderModalOnboardingFrame({
+        apiHost,
+        pathname: "/foo/bar",
+        search: "?x=foo",
+      });
+
+      expect(frame).toMatchInlineSnapshot(`
+        <iframe
+          allowtransparency="true"
+          src="https://api.sandbox.meso.network/modal/onboarding/foo/bar?x=foo"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+        />
+      `);
+    });
+
     test("renders iframe element with deep link", () => {
       const frame = renderModalOnboardingFrame({
         apiHost,

--- a/packages/meso-js/test/validators.test.ts
+++ b/packages/meso-js/test/validators.test.ts
@@ -506,7 +506,16 @@ describe("validators", () => {
 
   describe("INITIATE_MODAL_ONBOARDING", () => {
     describe("success", () => {
-      test("is valid", () => {
+      test("is valid w/o search", () => {
+        expect(
+          validateMessage({
+            kind: MessageKind.INITIATE_MODAL_ONBOARDING,
+            payload: { initialPathname: "/foo" },
+          }),
+        ).toBe(true);
+      });
+
+      test("is valid w/search", () => {
         expect(
           validateMessage({
             kind: MessageKind.INITIATE_MODAL_ONBOARDING,

--- a/packages/meso-js/test/validators.test.ts
+++ b/packages/meso-js/test/validators.test.ts
@@ -510,7 +510,7 @@ describe("validators", () => {
         expect(
           validateMessage({
             kind: MessageKind.INITIATE_MODAL_ONBOARDING,
-            payload: { initialPathname: "/foo" },
+            payload: { initialPathname: "/foo", search: "?foo" },
           }),
         ).toBe(true);
       });


### PR DESCRIPTION
In order to support partner-specific settings (such as themes), we need to be able to pass configuration data to the modal onboarding frame that can be negotiated _before_ standing up the transfer application inside the iframe. This PR enables shuttling a `search` field with the `INITIATE_MODAL_ONBOARDING` event.