### PR TITLE
explicitly set origin referrer policy on iframe

### DIFF
--- a/.changeset/old-games-teach.md
+++ b/.changeset/old-games-teach.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+explicitly set origin referrer policy on iframe

--- a/.changeset/old-games-teach.md
+++ b/.changeset/old-games-teach.md
@@ -2,4 +2,4 @@
 "@meso-network/meso-js": patch
 ---
 
-explicitly set origin referrer policy on iframe
+Explicitly set [referrerPolicy](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy) on Meso iframes. This prevents a bug in Firefox browsers where frames cannot establish their parent's origin using `document.referrer` if the parent has a no-referrer policy set.

--- a/cspell.json
+++ b/cspell.json
@@ -26,7 +26,8 @@
     "solana",
     "tsbuildinfo",
     "typecheck",
-    "webviews"
+    "webviews",
+    "referrerPolicy"
   ],
   "ignoreWords": [],
   "ignoreRegExpList": ["/solana:(\\w+)/"],

--- a/packages/meso-js/src/frame.ts
+++ b/packages/meso-js/src/frame.ts
@@ -45,6 +45,7 @@ const configureFramePositioningStyles = (iframe: HTMLIFrameElement) => {
 const renderIframe = (src: string, containerElement: Element | null) => {
   const iframe = document.createElement("iframe");
   iframe.src = src;
+  iframe.setAttribute("referrer", "origin");
 
   configureFrameCommonStyles(iframe);
 
@@ -78,6 +79,7 @@ export const renderModalOnboardingFrame = ({
   const iframe = document.createElement("iframe");
   iframe.src = src;
   iframe.setAttribute("allowtransparency", "true");
+  iframe.setAttribute("referrer", "origin");
 
   configureFrameCommonStyles(iframe);
   configureFramePositioningStyles(iframe);

--- a/packages/meso-js/src/frame.ts
+++ b/packages/meso-js/src/frame.ts
@@ -45,7 +45,7 @@ const configureFramePositioningStyles = (iframe: HTMLIFrameElement) => {
 const renderIframe = (src: string, containerElement: Element | null) => {
   const iframe = document.createElement("iframe");
   iframe.src = src;
-  iframe.setAttribute("referrer", "origin");
+  iframe.setAttribute("referrerPolicy", "origin");
 
   configureFrameCommonStyles(iframe);
 
@@ -79,7 +79,7 @@ export const renderModalOnboardingFrame = ({
   const iframe = document.createElement("iframe");
   iframe.src = src;
   iframe.setAttribute("allowtransparency", "true");
-  iframe.setAttribute("referrer", "origin");
+  iframe.setAttribute("referrerPolicy", "origin");
 
   configureFrameCommonStyles(iframe);
   configureFramePositioningStyles(iframe);

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -73,7 +73,7 @@ describe("frame", () => {
       expect(setupFrameRes.element.attributes).toMatchInlineSnapshot(`
         NamedNodeMap {
           "allowtransparency": "true",
-          "referrer": "origin",
+          "referrerpolicy": "origin",
           "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&sourceAsset=USD&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification&mode=embedded",
           "style": "box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;",
         }
@@ -119,7 +119,7 @@ describe("frame", () => {
       expect(frame).toMatchInlineSnapshot(`
         <iframe
           allowtransparency="true"
-          referrer="origin"
+          referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/foo/bar"
           style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
         />
@@ -136,7 +136,7 @@ describe("frame", () => {
       expect(frame).toMatchInlineSnapshot(`
         <iframe
           allowtransparency="true"
-          referrer="origin"
+          referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/foo/bar?x=foo"
           style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
         />
@@ -152,7 +152,7 @@ describe("frame", () => {
       expect(frame).toMatchInlineSnapshot(`
         <iframe
           allowtransparency="true"
-          referrer="origin"
+          referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/deep"
           style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
         />
@@ -168,7 +168,7 @@ describe("frame", () => {
       expect(frame).toMatchInlineSnapshot(`
         <iframe
           allowtransparency="true"
-          referrer="origin"
+          referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/deep"
           style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
         />

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -71,12 +71,13 @@ describe("frame", () => {
       );
       expect(setupFrameRes.element).toBeInTheDocument();
       expect(setupFrameRes.element.attributes).toMatchInlineSnapshot(`
-      NamedNodeMap {
-        "allowtransparency": "true",
-        "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&sourceAsset=USD&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification&mode=embedded",
-        "style": "box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;",
-      }
-    `);
+        NamedNodeMap {
+          "allowtransparency": "true",
+          "referrer": "origin",
+          "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&sourceAsset=USD&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification&mode=embedded",
+          "style": "box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;",
+        }
+      `);
     });
 
     test("invoking remove callback removes iframe from document", () => {
@@ -116,12 +117,13 @@ describe("frame", () => {
       });
 
       expect(frame).toMatchInlineSnapshot(`
-          <iframe
-            allowtransparency="true"
-            src="https://api.sandbox.meso.network/modal/onboarding/foo/bar"
-            style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
-          />
-        `);
+        <iframe
+          allowtransparency="true"
+          referrer="origin"
+          src="https://api.sandbox.meso.network/modal/onboarding/foo/bar"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+        />
+      `);
     });
 
     test("renders iframe element with provided pathname and query string", () => {
@@ -134,6 +136,7 @@ describe("frame", () => {
       expect(frame).toMatchInlineSnapshot(`
         <iframe
           allowtransparency="true"
+          referrer="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/foo/bar?x=foo"
           style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
         />
@@ -147,12 +150,13 @@ describe("frame", () => {
       });
 
       expect(frame).toMatchInlineSnapshot(`
-          <iframe
-            allowtransparency="true"
-            src="https://api.sandbox.meso.network/modal/onboarding/deep"
-            style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
-          />
-        `);
+        <iframe
+          allowtransparency="true"
+          referrer="origin"
+          src="https://api.sandbox.meso.network/modal/onboarding/deep"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+        />
+      `);
     });
 
     test("cleans pathname", () => {
@@ -162,12 +166,13 @@ describe("frame", () => {
       });
 
       expect(frame).toMatchInlineSnapshot(`
-          <iframe
-            allowtransparency="true"
-            src="https://api.sandbox.meso.network/modal/onboarding/deep"
-            style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
-          />
-        `);
+        <iframe
+          allowtransparency="true"
+          referrer="origin"
+          src="https://api.sandbox.meso.network/modal/onboarding/deep"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+        />
+      `);
     });
   });
 });


### PR DESCRIPTION
For partners who have their referrer policy set to `no-referrer`, Meso's iframe is unable to load in Firefox due to `location.ancestorOrigins` also not being set in FireFox. In order to prevent this issue, we explicitly set the `referrerPolicy` on the iframe html node to `origin`.