### PR TITLE
feat(@meso-network/meso-js): 🚸 ensure modal iframes are rendered at the highest z-index

### DIFF
--- a/.changeset/good-shrimps-punch.md
+++ b/.changeset/good-shrimps-punch.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Ensure modal iframes are rendered at the highest allowed `z-index` (`2147483647`). This forces the Meso UI to live above all other elements in the [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context).

--- a/packages/meso-js/src/frame.ts
+++ b/packages/meso-js/src/frame.ts
@@ -38,7 +38,9 @@ const configureFramePositioningStyles = (iframe: HTMLIFrameElement) => {
   iframe.style.position = "fixed";
   iframe.style.left = "0";
   iframe.style.top = "0";
-  iframe.style.zIndex = "9999";
+  // https://x.com/wesbos/status/1796201727529513377
+  // "It’s the largest integer that fits in 32 bits, so it’s the highest z-index you can give something in CSS" – https://x.com/wesbos/status/1796209959509578212
+  iframe.style.zIndex = "2147483647";
 };
 
 // Render the iframe for the "embedded" flow (full viewport modal)

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -97,7 +97,7 @@ describe("frame", () => {
       );
       var style = setupFrameRes.element.style;
       expect(style.display).toBe("");
-      expect(style.zIndex).toBe("2147483647q");
+      expect(style.zIndex).toBe("2147483647");
 
       setupFrameRes.hide();
 

--- a/packages/meso-js/test/frame.test.ts
+++ b/packages/meso-js/test/frame.test.ts
@@ -75,7 +75,7 @@ describe("frame", () => {
           "allowtransparency": "true",
           "referrerpolicy": "origin",
           "src": "https://api.sandbox.meso.network/app?partnerId=partnerId&network=eip155%3A1&walletAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&sourceAmount=100&sourceAsset=USD&destinationAsset=ETH&layoutPosition=top-right&layoutOffset=0&version=1.0.0&authenticationStrategy=headless_wallet_verification&mode=embedded",
-          "style": "box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;",
+          "style": "box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 2147483647;",
         }
       `);
     });
@@ -97,7 +97,7 @@ describe("frame", () => {
       );
       var style = setupFrameRes.element.style;
       expect(style.display).toBe("");
-      expect(style.zIndex).toBe("9999");
+      expect(style.zIndex).toBe("2147483647q");
 
       setupFrameRes.hide();
 
@@ -121,7 +121,7 @@ describe("frame", () => {
           allowtransparency="true"
           referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/foo/bar"
-          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 2147483647;"
         />
       `);
     });
@@ -138,7 +138,7 @@ describe("frame", () => {
           allowtransparency="true"
           referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/foo/bar?x=foo"
-          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 2147483647;"
         />
       `);
     });
@@ -154,7 +154,7 @@ describe("frame", () => {
           allowtransparency="true"
           referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/deep"
-          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 2147483647;"
         />
       `);
     });
@@ -170,7 +170,7 @@ describe("frame", () => {
           allowtransparency="true"
           referrerpolicy="origin"
           src="https://api.sandbox.meso.network/modal/onboarding/deep"
-          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 9999;"
+          style="box-sizing: border-box; background-color: transparent; color-scheme: auto; width: 100%; height: 100%; position: fixed; left: 0px; top: 0px; z-index: 2147483647;"
         />
       `);
     });


### PR DESCRIPTION
There are issues where in partner applications, Meso modals may render below other highly z-indexed elements. This sets the `z-index` to `2147483647` which is the highest number allowed.

See [this thread](https://x.com/wesbos/status/1796201727529513377) for more, specifically, this [reply](https://x.com/wesbos/status/1796209959509578212):

> It’s the largest integer that fits in 32 bits, so it’s the highest z-index you can give something in CSS

**Note:** Migration to a `<dialog>` element is on the roadmap but we do not have a definitive timeline for its release.