### PR TITLE
feat(@meso-network/meso-js): render iframes from new subdomain 

### DIFF
--- a/.changeset/shaggy-ants-attack.md
+++ b/.changeset/shaggy-ants-attack.md
@@ -1,0 +1,5 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Launch iframes from `transfer.meso.network` host.

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -87,13 +87,13 @@ with the correct values per-environment.
 **Sandbox:**
 
 ```sh
-Content-Security-Policy: frame-src https://api.sandbox.meso.network/; connect-src https://api.sandbox.meso.network/;
+Content-Security-Policy: frame-src https://*.sandbox.meso.network/; connect-src https://*.sandbox.meso.network/;
 ```
 
 **Production:**
 
 ```sh
-Content-Security-Policy: frame-src https://api.meso.network/; connect-src https://api.meso.network/;
+Content-Security-Policy: frame-src https://*.meso.network/; connect-src https://*.meso.network/;
 ```
 
 ## Usage

--- a/packages/meso-js/src/utils.ts
+++ b/packages/meso-js/src/utils.ts
@@ -3,10 +3,10 @@ import { Environment } from "./types";
 export const apiHosts: { readonly [key in Environment]: string } = {
   [Environment.LOCAL]: "http://localhost:5173",
   [Environment.LOCAL_PROXY]: "http://localhost:4001",
-  [Environment.DEV]: "https://api.dev.meso.plumbing",
-  [Environment.PREVIEW]: "https://api.preview.meso.plumbing",
-  [Environment.SANDBOX]: "https://api.sandbox.meso.network",
-  [Environment.PRODUCTION]: "https://api.meso.network",
+  [Environment.DEV]: "https://transfer.dev.meso.plumbing",
+  [Environment.PREVIEW]: "https://transfer.preview.meso.plumbing",
+  [Environment.SANDBOX]: "https://transfer.sandbox.meso.network",
+  [Environment.PRODUCTION]: "https://transfer.meso.network",
 };
 
 export const NOOP_TRANSFER_INSTANCE = { destroy: () => {} };

--- a/packages/meso-js/test/inlineTransfer.test.ts
+++ b/packages/meso-js/test/inlineTransfer.test.ts
@@ -120,7 +120,7 @@ describe("inlineTransfer", () => {
       } as InlineTransferConfiguration);
       expect(setupFrameMock).toHaveBeenCalledOnce();
       expect(setupFrameMock.mock.lastCall[0]).toMatchInlineSnapshot(
-        '"https://api.sandbox.meso.network"',
+        '"https://transfer.sandbox.meso.network"',
       );
       expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
         { version: expect.any(String) },
@@ -144,7 +144,7 @@ describe("inlineTransfer", () => {
       expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`
       [
         {
-          "apiHost": "https://api.sandbox.meso.network",
+          "apiHost": "https://transfer.sandbox.meso.network",
           "frame": {
             "remove": [MockFunction spy],
           },
@@ -184,7 +184,7 @@ describe("inlineTransfer", () => {
       } as InlineTransferConfiguration);
       expect(setupFrameMock).toHaveBeenCalledOnce();
       expect(setupFrameMock.mock.lastCall[0]).toMatchInlineSnapshot(
-        '"https://api.sandbox.meso.network"',
+        '"https://transfer.sandbox.meso.network"',
       );
       expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
         { version: expect.any(String) },
@@ -208,7 +208,7 @@ describe("inlineTransfer", () => {
       expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`
       [
         {
-          "apiHost": "https://api.sandbox.meso.network",
+          "apiHost": "https://transfer.sandbox.meso.network",
           "frame": {
             "remove": [MockFunction spy],
           },

--- a/packages/meso-js/test/transfer.test.ts
+++ b/packages/meso-js/test/transfer.test.ts
@@ -66,7 +66,7 @@ describe("transfer", () => {
     } as CashInConfiguration);
     expect(setupFrameMock).toHaveBeenCalledOnce();
     expect(setupFrameMock.mock.lastCall[0]).toMatchInlineSnapshot(
-      '"https://api.sandbox.meso.network"',
+      '"https://transfer.sandbox.meso.network"',
     );
     expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
       { version: expect.any(String) },
@@ -92,7 +92,7 @@ describe("transfer", () => {
     expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`
       [
         {
-          "apiHost": "https://api.sandbox.meso.network",
+          "apiHost": "https://transfer.sandbox.meso.network",
           "frame": {
             "remove": [MockFunction spy],
           },
@@ -123,7 +123,7 @@ describe("transfer", () => {
     } as CashOutConfiguration);
     expect(setupFrameMock).toHaveBeenCalledOnce();
     expect(setupFrameMock.mock.lastCall[0]).toMatchInlineSnapshot(
-      '"https://api.sandbox.meso.network"',
+      '"https://transfer.sandbox.meso.network"',
     );
     expect(setupFrameMock.mock.lastCall[1]).toMatchInlineSnapshot(
       { version: expect.any(String) },
@@ -149,7 +149,7 @@ describe("transfer", () => {
     expect(setupBusMock.mock.lastCall).toMatchInlineSnapshot(`
       [
         {
-          "apiHost": "https://api.sandbox.meso.network",
+          "apiHost": "https://transfer.sandbox.meso.network",
           "frame": {
             "remove": [MockFunction spy],
           },


### PR DESCRIPTION
Previously, we were using `api.meso.network` for our iframes. We are now migrating to `transfer.meso.network`.