### PR TITLE
feat(@meso-network/meso-js): :wastebasket: deprecate MATIC in favor of POL

### DIFF
--- a/.changeset/large-keys-kneel.md
+++ b/.changeset/large-keys-kneel.md
@@ -1,0 +1,7 @@
+---
+"@meso-network/meso-js": patch
+---
+
+Deprecate `MATIC` in favor of `POL`. As of September 4, 2024, the `MATIC` token is now `POL` ([read more](https://polygon.technology/blog/save-the-date-matic-pol-migration-coming-september-4th-everything-you-need-to-know)).
+
+This release deprecates `Asset.MATIC` which will be removed in a future version. Instead, `Asset.POL` should be used.

--- a/.changeset/large-keys-kneel.md
+++ b/.changeset/large-keys-kneel.md
@@ -1,5 +1,5 @@
 ---
-"@meso-network/meso-js": patch
+"@meso-network/meso-js": minor
 ---
 
 Deprecate `MATIC` in favor of `POL`. As of September 4, 2024, the `MATIC` token is now `POL` ([read more](https://polygon.technology/blog/save-the-date-matic-pol-migration-coming-september-4th-everything-you-need-to-know)).

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -357,7 +357,7 @@ enum Asset {
   ETH = "ETH"
   SOL = "SOL"
   USDC = "USDC"
-  MATIC = "MATIC",
+  POL = "POL"
 }
 
 enum Environment {

--- a/packages/meso-js/README.md
+++ b/packages/meso-js/README.md
@@ -842,7 +842,7 @@ See [unsupported asset errors](#unsupported-asset-errors) for more.
 {
   kind: "UNSUPPORTED_ASSET_ERROR",
   payload: {
-    message: "\"destinationAsset\" must be a supported asset: ETH,SOL,USDC,MATIC.",
+    message: "\"destinationAsset\" must be a supported asset: ETH,SOL,USDC,MATIC,POL.",
   }
 }
 ```

--- a/packages/meso-js/src/types.ts
+++ b/packages/meso-js/src/types.ts
@@ -137,7 +137,9 @@ export enum Asset {
   ETH = "ETH",
   SOL = "SOL",
   USDC = "USDC",
+  /** @deprecated Use `POL` instead. */
   MATIC = "MATIC",
+  POL = "POL",
 
   // FiatAsset
   USD = "USD",
@@ -148,6 +150,7 @@ export const CryptoAsset = {
   [Asset.SOL]: Asset.SOL,
   [Asset.USDC]: Asset.USDC,
   [Asset.MATIC]: Asset.MATIC,
+  [Asset.POL]: Asset.POL,
 } as const;
 
 export const FiatAsset = {

--- a/packages/meso-js/test/validateConfiguration.test.ts
+++ b/packages/meso-js/test/validateConfiguration.test.ts
@@ -772,17 +772,17 @@ describe("validateConfiguration", () => {
       ).toBe(false);
       expect(onEvent).toHaveBeenCalledOnce();
       expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "UNSUPPORTED_ASSET_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"destinationAsset\\" must be a supported Asset: ETH,SOL,USDC,MATIC,USD.",
+        [
+          {
+            "kind": "UNSUPPORTED_ASSET_ERROR",
+            "payload": {
+              "error": {
+                "message": "\\"destinationAsset\\" must be a supported Asset: ETH,SOL,USDC,MATIC,POL,USD.",
+              },
             },
           },
-        },
-      ]
-    `);
+        ]
+      `);
     });
 
     test("non-CryptoAsset sourceAsset when destinationAsset is FiatAsset emits", () => {
@@ -803,17 +803,17 @@ describe("validateConfiguration", () => {
       ).toBe(false);
       expect(onEvent).toHaveBeenCalledOnce();
       expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "UNSUPPORTED_ASSET_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"sourceAsset\\" must be a supported CryptoAsset for Cash-out: ETH,SOL,USDC,MATIC.",
+        [
+          {
+            "kind": "UNSUPPORTED_ASSET_ERROR",
+            "payload": {
+              "error": {
+                "message": "\\"sourceAsset\\" must be a supported CryptoAsset for Cash-out: ETH,SOL,USDC,MATIC,POL.",
+              },
             },
           },
-        },
-      ]
-    `);
+        ]
+      `);
     });
 
     test("non-FiatAsset sourceAsset when destinationAsset is CryptoAsset emits", () => {
@@ -1314,17 +1314,17 @@ describe("validateConfiguration", () => {
       ).toBe(false);
       expect(onEvent).toHaveBeenCalledOnce();
       expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "UNSUPPORTED_ASSET_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"destinationAsset\\" must be a supported Asset: ETH,SOL,USDC,MATIC,USD.",
+        [
+          {
+            "kind": "UNSUPPORTED_ASSET_ERROR",
+            "payload": {
+              "error": {
+                "message": "\\"destinationAsset\\" must be a supported Asset: ETH,SOL,USDC,MATIC,POL,USD.",
+              },
             },
           },
-        },
-      ]
-    `);
+        ]
+      `);
     });
 
     test("non-CryptoAsset sourceAsset when destinationAsset is FiatAsset emits", () => {
@@ -1345,17 +1345,17 @@ describe("validateConfiguration", () => {
       ).toBe(false);
       expect(onEvent).toHaveBeenCalledOnce();
       expect(onEvent.mock.lastCall).toMatchInlineSnapshot(`
-      [
-        {
-          "kind": "UNSUPPORTED_ASSET_ERROR",
-          "payload": {
-            "error": {
-              "message": "\\"sourceAsset\\" must be a supported CryptoAsset for Cash-out: ETH,SOL,USDC,MATIC.",
+        [
+          {
+            "kind": "UNSUPPORTED_ASSET_ERROR",
+            "payload": {
+              "error": {
+                "message": "\\"sourceAsset\\" must be a supported CryptoAsset for Cash-out: ETH,SOL,USDC,MATIC,POL.",
+              },
             },
           },
-        },
-      ]
-    `);
+        ]
+      `);
     });
 
     test("non-FiatAsset sourceAsset when destinationAsset is CryptoAsset emits", () => {


### PR DESCRIPTION
Polygon's MATIC token is now POL: https://polygon.technology/blog/save-the-date-matic-pol-migration-coming-september-4th-everything-you-need-to-know